### PR TITLE
fix: Broken navigation history

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,11 +1,11 @@
 import autoAnimate from "@formkit/auto-animate";
-import * as htmx from "htmx.org";
 import {
 	Chart,
-	registerables,
 	type ChartConfiguration,
 	type Point,
+	registerables,
 } from "chart.js";
+import * as htmx from "htmx.org";
 import "chartjs-adapter-date-fns";
 import { CmcCounter } from "./counter";
 

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -1,5 +1,5 @@
-import type { State } from "./state";
 import { type Question, gameQuestions, testQuestions } from "./questions";
+import type { State } from "./state";
 
 // Specify intervals in milliseconds to make it easier to work with time
 

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -1,6 +1,6 @@
 import { Elysia } from "elysia";
-import type { GameEvent, PlayerWorkerEvent, SaveStateEvent } from "./events";
 import { playerColor } from "../helpers/helpers";
+import type { GameEvent, PlayerWorkerEvent, SaveStateEvent } from "./events";
 import { gameQuestions } from "./questions";
 
 // biome-ignore lint/complexity/useLiteralKeys: <explanation>

--- a/src/game/workers/player-worker.spec.ts
+++ b/src/game/workers/player-worker.spec.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import {
-	fromPartial,
 	type PartialDeepObject,
+	fromPartial,
 } from "@total-typescript/shoehorn";
 import {
+	type WorkerState,
 	gameContinued,
 	gamePaused,
 	gameStarted,
@@ -11,7 +12,6 @@ import {
 	playerChangedUrl,
 	playerJoined,
 	playerLeft,
-	type WorkerState,
 } from "./player-worker";
 
 describe("player-worker", () => {

--- a/src/game/workers/player-worker.ts
+++ b/src/game/workers/player-worker.ts
@@ -10,13 +10,13 @@
  * The main thread then updates the game state accordingly.
  */
 import type { MainWorkerEvent, PlayerWorkerEvent } from "../events";
-import type { GameMode, GameStatus, PlayerLog } from "../state";
 import {
+	type QuestionType,
 	adjustIntervalLinear,
 	defaultInterval,
 	roundToQuestion,
-	type QuestionType,
 } from "../game";
+import type { GameMode, GameStatus, PlayerLog } from "../state";
 
 interface PlayerWorker extends Worker {
 	postMessage: (event: PlayerWorkerEvent) => void;

--- a/src/game/workers/state-worker.spec.ts
+++ b/src/game/workers/state-worker.spec.ts
@@ -1,11 +1,11 @@
+import { describe, expect, it } from "bun:test";
 import {
 	type PartialDeepObject,
 	fromPartial,
 } from "@total-typescript/shoehorn";
-import { expect, describe, it } from "bun:test";
 import { nanoid } from "nanoid";
-import type { State, StateWorker } from "../state";
 import type { SaveStateEvent } from "../events";
+import type { State, StateWorker } from "../state";
 
 describe("state-worker", () => {
 	it("should write state to file system", () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,15 +1,15 @@
 import staticPlugin from "@elysiajs/static";
 import { Elysia, t } from "elysia";
 
+import { state } from "./game/state";
 import { htmlPlugin } from "./middleware/html/html";
+import { htmxPlugin } from "./middleware/htmx/htmx";
 import { plugin as adminPlugin } from "./pages/admin";
 import { plugin as homePlugin } from "./pages/home/home";
 import { notFoundPlugin } from "./pages/not-found/not-found";
 import { plugin as playerPlugin } from "./pages/player";
-import { plugin as signupPlugin } from "./pages/signup";
-import { htmxPlugin } from "./middleware/htmx/htmx";
-import { state } from "./game/state";
 import { scoreboardPlugin } from "./pages/scoreboard/scoreboard";
+import { plugin as signupPlugin } from "./pages/signup";
 
 const app = new Elysia({
 	serve: {

--- a/src/layouts/main.tsx
+++ b/src/layouts/main.tsx
@@ -1,77 +1,81 @@
 interface LayoutProps {
-	page: string;
-	header?: JSX.Element | JSX.Element[];
-	children: JSX.Element | JSX.Element[];
+  page: string;
+  header?: JSX.Element | JSX.Element[];
+  children: JSX.Element | JSX.Element[];
 }
 
 export const HTMLLayout = ({ page, header, children }: LayoutProps) => {
-	return (
-		<html lang="en" class="h-full">
-			<head>
-				<title safe>{page} - Code Monkey Clash</title>
-				<link rel="stylesheet" href="/public/tailwind.css" />
-				<script src="/public/htmx.min.js" />
-				<script src="/public/response-targets.js" />
-				<script src="/public/sse.js" />
-				<script src="/public/client.js" />
-			</head>
-			<body class="bg-base-100" hx-ext="response-targets">
-				<header class="navbar absolute inset-x-0 top-0 z-50 bg-base-300">
-					<div class="flex-1">
-						<a class="btn btn-ghost text-xl text-primary" href="/">
-							Code Monkey Clash
-						</a>
-					</div>
-					{header as "safe"}
-				</header>
-				<main
-					id="main"
-					class="z-100 min-w-full min-h-screen flex flex-col grow py-16 px-8"
-				>
-					{children as "safe"}
-				</main>
-				<footer class="fixed bg-base-100 bg-opacity-20 inset-x-0 bottom-0 z-50 text-neutral-content text-end p-4">
-					A game by{" "}
-					<a class="link" href="https://snorre.io">
-						Snorre Magnus Davøen
-					</a>
-				</footer>
-			</body>
-		</html>
-	);
+  return (
+    <html lang="en" class="h-full">
+      <head>
+        <title safe>{page} - Code Monkey Clash</title>
+        <link rel="stylesheet" href="/public/tailwind.css" />
+        <script src="/public/htmx.min.js" />
+        <script src="/public/response-targets.js" />
+        <script src="/public/sse.js" />
+        <script src="/public/client.js" />
+      </head>
+      <body class="bg-base-100" hx-ext="response-targets" hx-boost="true">
+        <header class="navbar absolute inset-x-0 top-0 z-50 bg-base-300">
+          <div class="flex-1">
+            <a
+              class="btn btn-ghost text-xl text-primary"
+              href="/"
+              hx-push-url="true"
+            >
+              Code Monkey Clash
+            </a>
+          </div>
+          {header as "safe"}
+        </header>
+        <main
+          id="main"
+          class="z-100 min-w-full min-h-screen flex flex-col grow py-16 px-8"
+        >
+          {children as "safe"}
+        </main>
+        <footer class="fixed bg-base-100 bg-opacity-20 inset-x-0 bottom-0 z-50 text-neutral-content text-end p-4">
+          A game by{" "}
+          <a class="link" href="https://snorre.io">
+            Snorre Magnus Davøen
+          </a>
+        </footer>
+      </body>
+    </html>
+  );
 };
 
 export const HeroLayout = ({ page, children }: LayoutProps) => {
-	return (
-		<HTMLLayout page={page}>
-			<div class="hero-content text-center text-neutral-content">
-				{children as "safe"}
-			</div>
-			{/* Display credit in the bottom right corner */}
-			<div class="absolute bottom-0 right-0 p-4 text-xs text-neutral-content">
-				<p>
-					Photo by{" "}
-					<a href="https://unsplash.com/@alesnesetril" class="underline">
-						Ales Nesetril
-					</a>{" "}
-					on{" "}
-					<a
-						href="https://unsplash.com/photos/gray-and-black-laptop-computer-on-surface-Im7lZjxeLhg"
-						class="underline"
-					>
-						Unsplash
-					</a>
-				</p>
-			</div>
-		</HTMLLayout>
-	);
+  return (
+    <HTMLLayout page={page}>
+      <div class="hero-content text-center text-neutral-content">
+        {children as "safe"}
+      </div>
+      {/* Display credit in the bottom right corner */}
+      <div class="absolute bottom-0 right-0 p-4 text-xs text-neutral-content">
+        <p>
+          Photo by{" "}
+          <a href="https://unsplash.com/@alesnesetril" class="underline">
+            Ales Nesetril
+          </a>{" "}
+          on{" "}
+          <a
+            href="https://unsplash.com/photos/gray-and-black-laptop-computer-on-surface-Im7lZjxeLhg"
+            class="underline"
+          >
+            Unsplash
+          </a>
+        </p>
+      </div>
+    </HTMLLayout>
+  );
 };
 
 export const HXLayout = ({ page, children }: LayoutProps) => {
-	return (
-		<>
-			<title safe>{page} - Extreme Startup</title>
-			{children as "safe"}
-		</>
-	);
+  return (
+    <>
+      <title safe>{page} - Extreme Startup</title>
+      {children as "safe"}
+    </>
+  );
 };

--- a/src/layouts/main.tsx
+++ b/src/layouts/main.tsx
@@ -1,81 +1,81 @@
 interface LayoutProps {
-  page: string;
-  header?: JSX.Element | JSX.Element[];
-  children: JSX.Element | JSX.Element[];
+	page: string;
+	header?: JSX.Element | JSX.Element[];
+	children: JSX.Element | JSX.Element[];
 }
 
 export const HTMLLayout = ({ page, header, children }: LayoutProps) => {
-  return (
-    <html lang="en" class="h-full">
-      <head>
-        <title safe>{page} - Code Monkey Clash</title>
-        <link rel="stylesheet" href="/public/tailwind.css" />
-        <script src="/public/htmx.min.js" />
-        <script src="/public/response-targets.js" />
-        <script src="/public/sse.js" />
-        <script src="/public/client.js" />
-      </head>
-      <body class="bg-base-100" hx-ext="response-targets" hx-boost="true">
-        <header class="navbar absolute inset-x-0 top-0 z-50 bg-base-300">
-          <div class="flex-1">
-            <a
-              class="btn btn-ghost text-xl text-primary"
-              href="/"
-              hx-push-url="true"
-            >
-              Code Monkey Clash
-            </a>
-          </div>
-          {header as "safe"}
-        </header>
-        <main
-          id="main"
-          class="z-100 min-w-full min-h-screen flex flex-col grow py-16 px-8"
-        >
-          {children as "safe"}
-        </main>
-        <footer class="fixed bg-base-100 bg-opacity-20 inset-x-0 bottom-0 z-50 text-neutral-content text-end p-4">
-          A game by{" "}
-          <a class="link" href="https://snorre.io">
-            Snorre Magnus Davøen
-          </a>
-        </footer>
-      </body>
-    </html>
-  );
+	return (
+		<html lang="en" class="h-full">
+			<head>
+				<title safe>{page} - Code Monkey Clash</title>
+				<link rel="stylesheet" href="/public/tailwind.css" />
+				<script src="/public/htmx.min.js" />
+				<script src="/public/response-targets.js" />
+				<script src="/public/sse.js" />
+				<script src="/public/client.js" />
+			</head>
+			<body class="bg-base-100" hx-ext="response-targets" hx-boost="true">
+				<header class="navbar absolute inset-x-0 top-0 z-50 bg-base-300">
+					<div class="flex-1">
+						<a
+							class="btn btn-ghost text-xl text-primary"
+							href="/"
+							hx-push-url="true"
+						>
+							Code Monkey Clash
+						</a>
+					</div>
+					{header as "safe"}
+				</header>
+				<main
+					id="main"
+					class="z-100 min-w-full min-h-screen flex flex-col grow py-16 px-8"
+				>
+					{children as "safe"}
+				</main>
+				<footer class="fixed bg-base-100 bg-opacity-20 inset-x-0 bottom-0 z-50 text-neutral-content text-end p-4">
+					A game by{" "}
+					<a class="link" href="https://snorre.io">
+						Snorre Magnus Davøen
+					</a>
+				</footer>
+			</body>
+		</html>
+	);
 };
 
 export const HeroLayout = ({ page, children }: LayoutProps) => {
-  return (
-    <HTMLLayout page={page}>
-      <div class="hero-content text-center text-neutral-content">
-        {children as "safe"}
-      </div>
-      {/* Display credit in the bottom right corner */}
-      <div class="absolute bottom-0 right-0 p-4 text-xs text-neutral-content">
-        <p>
-          Photo by{" "}
-          <a href="https://unsplash.com/@alesnesetril" class="underline">
-            Ales Nesetril
-          </a>{" "}
-          on{" "}
-          <a
-            href="https://unsplash.com/photos/gray-and-black-laptop-computer-on-surface-Im7lZjxeLhg"
-            class="underline"
-          >
-            Unsplash
-          </a>
-        </p>
-      </div>
-    </HTMLLayout>
-  );
+	return (
+		<HTMLLayout page={page}>
+			<div class="hero-content text-center text-neutral-content">
+				{children as "safe"}
+			</div>
+			{/* Display credit in the bottom right corner */}
+			<div class="absolute bottom-0 right-0 p-4 text-xs text-neutral-content">
+				<p>
+					Photo by{" "}
+					<a href="https://unsplash.com/@alesnesetril" class="underline">
+						Ales Nesetril
+					</a>{" "}
+					on{" "}
+					<a
+						href="https://unsplash.com/photos/gray-and-black-laptop-computer-on-surface-Im7lZjxeLhg"
+						class="underline"
+					>
+						Unsplash
+					</a>
+				</p>
+			</div>
+		</HTMLLayout>
+	);
 };
 
 export const HXLayout = ({ page, children }: LayoutProps) => {
-  return (
-    <>
-      <title safe>{page} - Extreme Startup</title>
-      {children as "safe"}
-    </>
-  );
+	return (
+		<>
+			<title safe>{page} - Extreme Startup</title>
+			{children as "safe"}
+		</>
+	);
 };

--- a/src/middleware/sse/sse.ts
+++ b/src/middleware/sse/sse.ts
@@ -6,8 +6,8 @@
  */
 
 import { nanoid } from "nanoid";
-import type { State } from "../../game/state";
 import type { GameEvent } from "../../game/events";
+import type { State } from "../../game/state";
 
 /** Data to send to SSE clients (i.e. browsers) */
 interface SSECallbackResponse {

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -4,524 +4,523 @@ import { mapValidationError } from "../helpers/helpers";
 import { HTMLLayout, HXLayout } from "../layouts/main";
 import { basePluginSetup } from "../plugins";
 import {
-	type State,
-	removePlayer,
-	startGame,
-	stopGame,
-	pauseGame,
-	continueGame,
-	resetGame,
-	type Player,
-	nextRound,
-	previousRound,
+  type State,
+  removePlayer,
+  startGame,
+  stopGame,
+  pauseGame,
+  continueGame,
+  resetGame,
+  type Player,
+  nextRound,
+  previousRound,
 } from "../game/state";
 import { createSSEResponse } from "../middleware/sse/sse";
 
 interface FormProps {
-	secret?: string;
-	fieldErrors: Record<string, string>;
+  secret?: string;
+  fieldErrors: Record<string, string>;
 }
 
 const AdminLoginForm = ({ fieldErrors, secret }: FormProps) => {
-	return (
-		<div class="epic flex flex-col justify-center grow items-center">
-			<form
-				class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm w-full max-w-md flex flex-col items-stretch gap-4"
-				hx-post="/admin/login"
-				hx-target="this"
-				hx-swap="outerHTML"
-				hx-boost
-			>
-				<label class="form-control w-full">
-					<div class="label">
-						<span class="label-text">What is the admin secret?</span>
-					</div>
-					<input
-						type="password"
-						name="secret"
-						class="input input-bordered w-full"
-						value={secret}
-					/>
-					{fieldErrors["/secret"] ? (
-						<div class="label-text-alt mt-2 text-error" safe>
-							{fieldErrors["/secret"]}
-						</div>
-					) : null}
-				</label>
-				<button type="submit" class="btn btn-primary">
-					Login
-				</button>
-			</form>
-		</div>
-	);
+  return (
+    <div class="epic flex flex-col justify-center grow items-center">
+      <form
+        class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm w-full max-w-md flex flex-col items-stretch gap-4"
+        hx-post="/admin/login"
+        hx-target="this"
+        hx-swap="outerHTML"
+      >
+        <label class="form-control w-full">
+          <div class="label">
+            <span class="label-text">What is the admin secret?</span>
+          </div>
+          <input
+            type="password"
+            name="secret"
+            class="input input-bordered w-full"
+            value={secret}
+          />
+          {fieldErrors["/secret"] ? (
+            <div class="label-text-alt mt-2 text-error" safe>
+              {fieldErrors["/secret"]}
+            </div>
+          ) : null}
+        </label>
+        <button type="submit" class="btn btn-primary">
+          Login
+        </button>
+      </form>
+    </div>
+  );
 };
 
 interface RoundProps {
-	state: State;
+  state: State;
 }
 
 const Stats = ({ state }: RoundProps) => {
-	const totalRequests = state.players.reduce(
-		(acc, player) => acc + player.log.length,
-		0,
-	);
+  const totalRequests = state.players.reduce(
+    (acc, player) => acc + player.log.length,
+    0
+  );
 
-	return (
-		<div id="counter" class="stats stats-horizontal text-2xl max-w-full">
-			<div class="stat place-items-center">
-				<span class="stat-title">Game</span>
-				<span class="stat-value font-mono">
-					<cmc-counter
-						count={state.status === "playing" ? "true" : "false"}
-						date-time={state.gameStartedAt}
-					/>
-				</span>
-			</div>
-			<div class="stat place-items-center">
-				<span class="stat-title">Round</span>
-				<span class="stat-value font-mono">
-					<cmc-counter
-						count={state.status === "playing" ? "true" : "false"}
-						date-time={state.roundStartedAt}
-					/>
-				</span>
-			</div>
-			<div class="stat place-items-center">
-				<span class="stat-title">Players</span>
-				<span class="stat-value font-mono">{state.players.length}</span>
-			</div>
-			<div class="stat place-items-center">
-				<span class="stat-title">Total requests</span>
-				<span
-					class="stat-value font-mono"
-					hx-swap="innerHTML"
-					sse-swap="request-count"
-				>
-					{totalRequests}
-				</span>
-			</div>
-		</div>
-	);
+  return (
+    <div id="counter" class="stats stats-horizontal text-2xl max-w-full">
+      <div class="stat place-items-center">
+        <span class="stat-title">Game</span>
+        <span class="stat-value font-mono">
+          <cmc-counter
+            count={state.status === "playing" ? "true" : "false"}
+            date-time={state.gameStartedAt}
+          />
+        </span>
+      </div>
+      <div class="stat place-items-center">
+        <span class="stat-title">Round</span>
+        <span class="stat-value font-mono">
+          <cmc-counter
+            count={state.status === "playing" ? "true" : "false"}
+            date-time={state.roundStartedAt}
+          />
+        </span>
+      </div>
+      <div class="stat place-items-center">
+        <span class="stat-title">Players</span>
+        <span class="stat-value font-mono">{state.players.length}</span>
+      </div>
+      <div class="stat place-items-center">
+        <span class="stat-title">Total requests</span>
+        <span
+          class="stat-value font-mono"
+          hx-swap="innerHTML"
+          sse-swap="request-count"
+        >
+          {totalRequests}
+        </span>
+      </div>
+    </div>
+  );
 };
 
 const PlayOrStop = ({ state }: RoundProps) => {
-	const { status } = state;
+  const { status } = state;
 
-	return (
-		<form class="flex flex-row gap-8" method="POST" action="">
-			{status === "stopped" ? (
-				<>
-					<div class="flex flex-row gap-2">
-						<button
-							type="submit"
-							formmethod="POST"
-							formaction="/admin/start-game?mode=demo"
-							class="btn btn-outline btn-warning"
-						>
-							Start Demo
-						</button>
-						<button
-							type="submit"
-							formmethod="POST"
-							formaction="/admin/start-game?mode=game"
-							class="btn btn-outline btn-success"
-						>
-							Start Game
-						</button>
-					</div>
-					<div class="flex flex-row gap-2">
-						<button
-							type="submit"
-							formmethod="POST"
-							formaction="/admin/reset-game"
-							class="btn btn-outline btn-error"
-						>
-							Reset Game
-						</button>
-						<button
-							type="submit"
-							formmethod="POST"
-							formaction="/admin/reset-state"
-							class="btn btn-outline btn-error"
-						>
-							Reset Server
-						</button>
-					</div>
-				</>
-			) : null}
-			{status === "playing" ? (
-				<>
-					<button
-						type="submit"
-						formaction="/admin/pause-game"
-						class="btn btn-outline btn-warning"
-					>
-						Pause Game
-					</button>
-					<button
-						type="submit"
-						formaction="/admin/stop-game"
-						class="btn btn-outline btn-error"
-					>
-						Stop Game
-					</button>
-				</>
-			) : null}
-			{status === "paused" ? (
-				<button
-					type="submit"
-					formaction="/admin/continue-game"
-					class="btn btn-outline btn-success"
-				>
-					Continue Game
-				</button>
-			) : null}
-		</form>
-	);
+  return (
+    <form class="flex flex-row gap-8" method="POST" action="">
+      {status === "stopped" ? (
+        <>
+          <div class="flex flex-row gap-2">
+            <button
+              type="submit"
+              formmethod="POST"
+              formaction="/admin/start-game?mode=demo"
+              class="btn btn-outline btn-warning"
+            >
+              Start Demo
+            </button>
+            <button
+              type="submit"
+              formmethod="POST"
+              formaction="/admin/start-game?mode=game"
+              class="btn btn-outline btn-success"
+            >
+              Start Game
+            </button>
+          </div>
+          <div class="flex flex-row gap-2">
+            <button
+              type="submit"
+              formmethod="POST"
+              formaction="/admin/reset-game"
+              class="btn btn-outline btn-error"
+            >
+              Reset Game
+            </button>
+            <button
+              type="submit"
+              formmethod="POST"
+              formaction="/admin/reset-state"
+              class="btn btn-outline btn-error"
+            >
+              Reset Server
+            </button>
+          </div>
+        </>
+      ) : null}
+      {status === "playing" ? (
+        <>
+          <button
+            type="submit"
+            formaction="/admin/pause-game"
+            class="btn btn-outline btn-warning"
+          >
+            Pause Game
+          </button>
+          <button
+            type="submit"
+            formaction="/admin/stop-game"
+            class="btn btn-outline btn-error"
+          >
+            Stop Game
+          </button>
+        </>
+      ) : null}
+      {status === "paused" ? (
+        <button
+          type="submit"
+          formaction="/admin/continue-game"
+          class="btn btn-outline btn-success"
+        >
+          Continue Game
+        </button>
+      ) : null}
+    </form>
+  );
 };
 
 const Round = ({ state }: RoundProps) => {
-	const { round, status, mode } = state;
-	const total = mode === "demo" ? 1 : Math.floor(gameQuestions.length / 2);
-	return (
-		<div class="rounded-lg flex flex-col gap-4 justify-items-center">
-			<div class="flex flex-row justify-between items-center">
-				<div class="flex flex-row">
-					<PlayOrStop state={state} />
-				</div>
-				<p class="text-center text-2xl">
-					Round {status === "stopped" ? 0 : round}
-					&nbsp;of&nbsp;
-					{total}
-				</p>
-				<form class="" hx-trigger="click">
-					<div class="flex flex-row join gap-[1px]">
-						<button
-							class="join-item btn btn-outline btn-error"
-							type="submit"
-							action="/admin/previous-round"
-							disabled={status === "stopped" || round === 0}
-							hx-post="/admin/previous-round"
-						>
-							Previous Round
-						</button>
+  const { round, status, mode } = state;
+  const total = mode === "demo" ? 1 : Math.floor(gameQuestions.length / 2);
+  return (
+    <div class="rounded-lg flex flex-col gap-4 justify-items-center">
+      <div class="flex flex-row justify-between items-center">
+        <div class="flex flex-row">
+          <PlayOrStop state={state} />
+        </div>
+        <p class="text-center text-2xl">
+          Round {status === "stopped" ? 0 : round}
+          &nbsp;of&nbsp;
+          {total}
+        </p>
+        <form class="" hx-trigger="click">
+          <div class="flex flex-row join gap-[1px]">
+            <button
+              class="join-item btn btn-outline btn-error"
+              type="submit"
+              action="/admin/previous-round"
+              disabled={status === "stopped" || round === 0}
+              hx-post="/admin/previous-round"
+            >
+              Previous Round
+            </button>
 
-						<button
-							class="join-item btn btn-outline btn-success"
-							type="submit"
-							action="/admin/next-round"
-							disabled={status === "stopped" || round === total - 1}
-							hx-post="/admin/next-round"
-						>
-							Next Round
-						</button>
-					</div>
-				</form>
-			</div>
-			<progress
-				class="progress max-w-full progress-primary"
-				value={status === "stopped" ? 0 : round}
-				max={state.mode === "demo" ? 1 : total}
-			/>
-		</div>
-	);
+            <button
+              class="join-item btn btn-outline btn-success"
+              type="submit"
+              action="/admin/next-round"
+              disabled={status === "stopped" || round === total - 1}
+              hx-post="/admin/next-round"
+            >
+              Next Round
+            </button>
+          </div>
+        </form>
+      </div>
+      <progress
+        class="progress max-w-full progress-primary"
+        value={status === "stopped" ? 0 : round}
+        max={state.mode === "demo" ? 1 : total}
+      />
+    </div>
+  );
 };
 
 const PlayerRow = (player: Player) => {
-	const rowId = `player-${player.uuid}`;
-	return (
-		<tr class="odd:bg-base-300" id={rowId}>
-			<td>
-				<a
-					class="link link-hover"
-					href={`/players/${player.uuid}`}
-					hx-boost="true"
-					hx-target="#content"
-					hx-swap="outerHTML"
-					safe
-				>
-					{player.nick}
-				</a>
-			</td>
-			<td safe>{player.url}</td>
-			<td sse-swap={`player-score-${player.uuid}`} hx-swap="innerHTML">
-				{player.log?.[0]?.score ?? 0}
-			</td>
-			<td>
-				{player.playing ? (
-					<span class="text-success">Playing</span>
-				) : (
-					<span class="text-error">Not playing</span>
-				)}
-			</td>
-			<td>
-				<form
-					method="POST"
-					action="/admin/remove"
-					hx-post="/admin/remove"
-					hx-target={`#${rowId}`} // Replace row with (empty) hx response to remove it
-					hx-swap="outerHTML"
-				>
-					<input type="hidden" name="uuid" value={player.uuid} />
-					<button type="submit" class="btn btn-sm btn-outline btn-error">
-						Remove
-					</button>
-				</form>
-			</td>
-		</tr>
-	);
+  const rowId = `player-${player.uuid}`;
+  return (
+    <tr class="odd:bg-base-300" id={rowId}>
+      <td>
+        <a
+          class="link link-hover"
+          href={`/players/${player.uuid}`}
+          hx-target="#content"
+          hx-swap="outerHTML"
+          hx-push-url="true"
+          safe
+        >
+          {player.nick}
+        </a>
+      </td>
+      <td safe>{player.url}</td>
+      <td sse-swap={`player-score-${player.uuid}`} hx-swap="innerHTML">
+        {player.log?.[0]?.score ?? 0}
+      </td>
+      <td>
+        {player.playing ? (
+          <span class="text-success">Playing</span>
+        ) : (
+          <span class="text-error">Not playing</span>
+        )}
+      </td>
+      <td>
+        <form
+          method="POST"
+          action="/admin/remove"
+          hx-post="/admin/remove"
+          hx-target={`#${rowId}`} // Replace row with (empty) hx response to remove it
+          hx-swap="outerHTML"
+        >
+          <input type="hidden" name="uuid" value={player.uuid} />
+          <button type="submit" class="btn btn-sm btn-outline btn-error">
+            Remove
+          </button>
+        </form>
+      </td>
+    </tr>
+  );
 };
 
 interface AdminProps {
-	state: State;
+  state: State;
 }
 
 const Admin = ({ state }: AdminProps) => {
-	return (
-		<div
-			id="content"
-			class="epic pt-8 flex flex-col min-w-full max-w-full gap-8"
-			hx-ext="sse"
-			sse-connect="/admin/sse"
-		>
-			{/* Display round */}
-			<div class="flex flex-col gap-8 z-10 bg-base-100 bg-opacity-90 backdrop-blur-sm p-8 rounded-2xl">
-				<Round state={state} />
-				<Stats state={state} />
-			</div>
-			<div class="z-10 bg-base-100 bg-opacity-90 backdrop-blur-sm p-8 rounded-2xl">
-				<h2 class="hidden">Players</h2>
-				<div class="overflow-x-auto max-w-full h-full">
-					<table class="table text-">
-						<thead>
-							<tr>
-								<th>Nick</th>
-								<th>URL</th>
-								<th>Score</th>
-								<th>Status</th>
-								<th />
-							</tr>
-						</thead>
-						<tbody
-							class="auto-animate"
-							sse-swap="player-joined"
-							hx-swap="afterbegin"
-						>
-							{state.players
-								.toSorted((a, b) => a.score - b.score)
-								.map((player) => (
-									// biome-ignore lint/correctness/useJsxKeyInIterable: Don't need it here
-									<PlayerRow {...player} />
-								))}
-						</tbody>
-					</table>
-				</div>
-			</div>
-		</div>
-	);
+  return (
+    <div
+      id="content"
+      class="epic pt-8 flex flex-col min-w-full max-w-full gap-8"
+      hx-ext="sse"
+      sse-connect="/admin/sse"
+    >
+      {/* Display round */}
+      <div class="flex flex-col gap-8 z-10 bg-base-100 bg-opacity-90 backdrop-blur-sm p-8 rounded-2xl">
+        <Round state={state} />
+        <Stats state={state} />
+      </div>
+      <div class="z-10 bg-base-100 bg-opacity-90 backdrop-blur-sm p-8 rounded-2xl">
+        <h2 class="hidden">Players</h2>
+        <div class="overflow-x-auto max-w-full h-full">
+          <table class="table text-">
+            <thead>
+              <tr>
+                <th>Nick</th>
+                <th>URL</th>
+                <th>Score</th>
+                <th>Status</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody
+              class="auto-animate"
+              sse-swap="player-joined"
+              hx-swap="afterbegin"
+            >
+              {state.players
+                .toSorted((a, b) => a.score - b.score)
+                .map((player) => (
+                  // biome-ignore lint/correctness/useJsxKeyInIterable: Don't need it here
+                  <PlayerRow {...player} />
+                ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export const plugin = basePluginSetup()
-	.get("/admin", ({ htmx, cookie: { user }, store: { state } }) => {
-		const header = (
-			<div class="">
-				<a href="/admin/logout" class="btn btn-ghost">
-					Logout
-				</a>
-			</div>
-		);
+  .get("/admin", ({ htmx, cookie: { user }, store: { state } }) => {
+    const header = (
+      <div class="">
+        <a href="/admin/logout" class="btn btn-ghost" hx-push-url="true">
+          Logout
+        </a>
+      </div>
+    );
 
-		if (user.value === "admin") {
-			const Layout = htmx.is ? HXLayout : HTMLLayout;
-			return (
-				<Layout page="Admin" header={header}>
-					<Admin state={state} />
-				</Layout>
-			);
-		}
-		const Layout = htmx.is ? HXLayout : HTMLLayout;
-		return (
-			<Layout page="Sign Up" header={header}>
-				<AdminLoginForm fieldErrors={{}} />
-			</Layout>
-		);
-	})
-	.post(
-		"/admin/login",
-		({ body: { secret }, htmx, set, cookie: { user } }) => {
-			const fieldErrors: Record<string, string> = {};
+    if (user.value === "admin") {
+      const Layout = htmx.is ? HXLayout : HTMLLayout;
+      return (
+        <Layout page="Admin" header={header}>
+          <Admin state={state} />
+        </Layout>
+      );
+    }
+    const Layout = htmx.is ? HXLayout : HTMLLayout;
+    return (
+      <Layout page="Sign Up" header={header}>
+        <AdminLoginForm fieldErrors={{}} />
+      </Layout>
+    );
+  })
+  .post(
+    "/admin/login",
+    ({ body: { secret }, htmx, set, cookie: { user } }) => {
+      const fieldErrors: Record<string, string> = {};
 
-			// biome-ignore lint/complexity/useLiteralKeys: Bun.env is a record of unknown keys
-			if (secret !== Bun.env["CMC_SECRET"]) {
-				fieldErrors["/secret"] = "Invalid secret";
-			} else {
-				user.set({
-					value: "admin",
-					expires: new Date(Date.now() + 1000 * 60 * 60),
-					httpOnly: true,
-				});
-			}
+      // biome-ignore lint/complexity/useLiteralKeys: Bun.env is a record of unknown keys
+      if (secret !== Bun.env["CMC_SECRET"]) {
+        fieldErrors["/secret"] = "Invalid secret";
+      } else {
+        user.set({
+          value: "admin",
+          expires: new Date(Date.now() + 1000 * 60 * 60),
+          httpOnly: true,
+        });
+      }
 
-			if (Object.keys(fieldErrors).length) {
-				set.status = 400;
-				const Layout = htmx.is ? HXLayout : HTMLLayout;
-				return (
-					<Layout page="Admin">
-						<AdminLoginForm fieldErrors={fieldErrors} secret={""} />
-					</Layout>
-				);
-			}
+      if (Object.keys(fieldErrors).length) {
+        set.status = 400;
+        const Layout = htmx.is ? HXLayout : HTMLLayout;
+        return (
+          <Layout page="Admin">
+            <AdminLoginForm fieldErrors={fieldErrors} secret={""} />
+          </Layout>
+        );
+      }
 
-			if (htmx.is) {
-				htmx.redirect("/admin");
-			} else {
-				set.redirect = "/admin";
-			}
-		},
-		{
-			body: t.Object({
-				secret: t.String({}),
-			}),
-			error: ({ code, error, htmx, set }) => {
-				const Layout = htmx.is ? HXLayout : HTMLLayout;
-				if (code === "VALIDATION") {
-					set.status = 200;
-					const errors = mapValidationError(error as ValidationError);
-					return (
-						<Layout page="Admin">
-							<AdminLoginForm fieldErrors={errors} />
-						</Layout>
-					);
-				}
-				return (
-					<Layout page="Admin">
-						<AdminLoginForm fieldErrors={{}} />
-					</Layout>
-				);
-			},
-		},
-	)
-	.post(
-		"/admin/remove",
-		({ body: { uuid }, htmx, set, store: { state } }) => {
-			removePlayer(state, uuid);
-			if (htmx.is) {
-				htmx.location({ path: "/admin", target: "#main" });
-			} else {
-				set.redirect = "/admin";
-				return <></>;
-			}
-		},
-		{
-			body: t.Object({
-				uuid: t.String(),
-			}),
-		},
-	)
-	.post(
-		"/admin/start-game",
-		({ set, store: { state }, query: { mode } }) => {
-			startGame(state, mode);
-			set.redirect = "/admin";
-		},
-		{
-			query: t.Object({
-				mode: t.Union([t.Literal("demo"), t.Literal("game")]),
-			}),
-		},
-	)
-	.post("/admin/stop-game", ({ htmx, set, store: { state } }) => {
-		const Layout = htmx.is ? HXLayout : HTMLLayout;
-		stopGame(state);
+      if (htmx.is) {
+        htmx.redirect("/admin");
+      } else {
+        set.redirect = "/admin";
+      }
+    },
+    {
+      body: t.Object({
+        secret: t.String({}),
+      }),
+      error: ({ code, error, htmx, set }) => {
+        const Layout = htmx.is ? HXLayout : HTMLLayout;
+        if (code === "VALIDATION") {
+          set.status = 200;
+          const errors = mapValidationError(error as ValidationError);
+          return (
+            <Layout page="Admin">
+              <AdminLoginForm fieldErrors={errors} />
+            </Layout>
+          );
+        }
+        return (
+          <Layout page="Admin">
+            <AdminLoginForm fieldErrors={{}} />
+          </Layout>
+        );
+      },
+    }
+  )
+  .post(
+    "/admin/remove",
+    ({ body: { uuid }, htmx, set, store: { state } }) => {
+      removePlayer(state, uuid);
+      if (htmx.is) {
+        htmx.location({ path: "/admin", target: "#main" });
+      } else {
+        set.redirect = "/admin";
+        return <></>;
+      }
+    },
+    {
+      body: t.Object({
+        uuid: t.String(),
+      }),
+    }
+  )
+  .post(
+    "/admin/start-game",
+    ({ set, store: { state }, query: { mode } }) => {
+      startGame(state, mode);
+      set.redirect = "/admin";
+    },
+    {
+      query: t.Object({
+        mode: t.Union([t.Literal("demo"), t.Literal("game")]),
+      }),
+    }
+  )
+  .post("/admin/stop-game", ({ htmx, set, store: { state } }) => {
+    const Layout = htmx.is ? HXLayout : HTMLLayout;
+    stopGame(state);
 
-		if (htmx.is) {
-			return (
-				<Layout page="Admin">
-					<PlayOrStop state={state} />
-				</Layout>
-			);
-		}
+    if (htmx.is) {
+      return (
+        <Layout page="Admin">
+          <PlayOrStop state={state} />
+        </Layout>
+      );
+    }
 
-		set.redirect = "/admin";
-	})
-	.post("/admin/pause-game", ({ htmx, set, store: { state } }) => {
-		pauseGame(state);
+    set.redirect = "/admin";
+  })
+  .post("/admin/pause-game", ({ htmx, set, store: { state } }) => {
+    pauseGame(state);
 
-		if (htmx.is) {
-			htmx.location({ path: "/admin", target: "#main" });
-		} else {
-			set.redirect = "/admin";
-		}
-	})
-	.post("/admin/continue-game", ({ htmx, set, store: { state } }) => {
-		continueGame(state);
+    if (htmx.is) {
+      htmx.location({ path: "/admin", target: "#main" });
+    } else {
+      set.redirect = "/admin";
+    }
+  })
+  .post("/admin/continue-game", ({ htmx, set, store: { state } }) => {
+    continueGame(state);
 
-		if (htmx.is) {
-			htmx.location({ path: "/admin", target: "#main" });
-		} else {
-			set.redirect = "/admin";
-		}
-	})
-	.post("/admin/reset-game", ({ htmx, set, store: { state } }) => {
-		resetGame(state);
+    if (htmx.is) {
+      htmx.location({ path: "/admin", target: "#main" });
+    } else {
+      set.redirect = "/admin";
+    }
+  })
+  .post("/admin/reset-game", ({ htmx, set, store: { state } }) => {
+    resetGame(state);
 
-		if (htmx.is) {
-			htmx.location({ path: "/admin", target: "#main" });
-		} else {
-			set.redirect = "/admin";
-		}
-	})
-	.post("/admin/next-round", ({ htmx, set, store: { state } }) => {
-		nextRound(state);
+    if (htmx.is) {
+      htmx.location({ path: "/admin", target: "#main" });
+    } else {
+      set.redirect = "/admin";
+    }
+  })
+  .post("/admin/next-round", ({ htmx, set, store: { state } }) => {
+    nextRound(state);
 
-		if (htmx.is) {
-			htmx.location({ path: "/admin", target: "#main" });
-		} else {
-			set.redirect = "/admin";
-		}
-	})
-	.post("/admin/previous-round", ({ htmx, set, store: { state } }) => {
-		previousRound(state);
+    if (htmx.is) {
+      htmx.location({ path: "/admin", target: "#main" });
+    } else {
+      set.redirect = "/admin";
+    }
+  })
+  .post("/admin/previous-round", ({ htmx, set, store: { state } }) => {
+    previousRound(state);
 
-		if (htmx.is) {
-			htmx.location({ path: "/admin", target: "#main" });
-		} else {
-			set.redirect = "/admin";
-		}
-	})
-	.get("/admin/sse", ({ store: { state }, request }) => {
-		const stream = createSSEResponse(state, request, [
-			(state, event) => {
-				if (event.type === "player-answer") {
-					const player = state.players.find((p) => p.uuid === event.uuid);
-					return player
-						? [
-								{
-									event: `player-score-${player.uuid}`,
-									data: `${event.log.score}`,
-								},
-								{
-									event: "request-count",
-									data: `${state.players.reduce(
-										(acc, p) => acc + p.log.length,
-										0,
-									)}`,
-								},
-							]
-						: [];
-				}
+    if (htmx.is) {
+      htmx.location({ path: "/admin", target: "#main" });
+    } else {
+      set.redirect = "/admin";
+    }
+  })
+  .get("/admin/sse", ({ store: { state }, request }) => {
+    const stream = createSSEResponse(state, request, [
+      (state, event) => {
+        if (event.type === "player-answer") {
+          const player = state.players.find((p) => p.uuid === event.uuid);
+          return player
+            ? [
+                {
+                  event: `player-score-${player.uuid}`,
+                  data: `${event.log.score}`,
+                },
+                {
+                  event: "request-count",
+                  data: `${state.players.reduce(
+                    (acc, p) => acc + p.log.length,
+                    0
+                  )}`,
+                },
+              ]
+            : [];
+        }
 
-				if (event.type === "player-joined") {
-					return [
-						{
-							event: "player-joined",
-							data: `${<PlayerRow {...event} />}`,
-						},
-					];
-				}
-				return [];
-			},
-		]);
+        if (event.type === "player-joined") {
+          return [
+            {
+              event: "player-joined",
+              data: `${(<PlayerRow {...event} />)}`,
+            },
+          ];
+        }
+        return [];
+      },
+    ]);
 
-		return stream;
-	});
+    return stream;
+  });

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1,526 +1,526 @@
 import { type ValidationError, t } from "elysia";
 import { gameQuestions } from "../game/questions";
+import {
+	type Player,
+	type State,
+	continueGame,
+	nextRound,
+	pauseGame,
+	previousRound,
+	removePlayer,
+	resetGame,
+	startGame,
+	stopGame,
+} from "../game/state";
 import { mapValidationError } from "../helpers/helpers";
 import { HTMLLayout, HXLayout } from "../layouts/main";
-import { basePluginSetup } from "../plugins";
-import {
-  type State,
-  removePlayer,
-  startGame,
-  stopGame,
-  pauseGame,
-  continueGame,
-  resetGame,
-  type Player,
-  nextRound,
-  previousRound,
-} from "../game/state";
 import { createSSEResponse } from "../middleware/sse/sse";
+import { basePluginSetup } from "../plugins";
 
 interface FormProps {
-  secret?: string;
-  fieldErrors: Record<string, string>;
+	secret?: string;
+	fieldErrors: Record<string, string>;
 }
 
 const AdminLoginForm = ({ fieldErrors, secret }: FormProps) => {
-  return (
-    <div class="epic flex flex-col justify-center grow items-center">
-      <form
-        class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm w-full max-w-md flex flex-col items-stretch gap-4"
-        hx-post="/admin/login"
-        hx-target="this"
-        hx-swap="outerHTML"
-      >
-        <label class="form-control w-full">
-          <div class="label">
-            <span class="label-text">What is the admin secret?</span>
-          </div>
-          <input
-            type="password"
-            name="secret"
-            class="input input-bordered w-full"
-            value={secret}
-          />
-          {fieldErrors["/secret"] ? (
-            <div class="label-text-alt mt-2 text-error" safe>
-              {fieldErrors["/secret"]}
-            </div>
-          ) : null}
-        </label>
-        <button type="submit" class="btn btn-primary">
-          Login
-        </button>
-      </form>
-    </div>
-  );
+	return (
+		<div class="epic flex flex-col justify-center grow items-center">
+			<form
+				class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm w-full max-w-md flex flex-col items-stretch gap-4"
+				hx-post="/admin/login"
+				hx-target="this"
+				hx-swap="outerHTML"
+			>
+				<label class="form-control w-full">
+					<div class="label">
+						<span class="label-text">What is the admin secret?</span>
+					</div>
+					<input
+						type="password"
+						name="secret"
+						class="input input-bordered w-full"
+						value={secret}
+					/>
+					{fieldErrors["/secret"] ? (
+						<div class="label-text-alt mt-2 text-error" safe>
+							{fieldErrors["/secret"]}
+						</div>
+					) : null}
+				</label>
+				<button type="submit" class="btn btn-primary">
+					Login
+				</button>
+			</form>
+		</div>
+	);
 };
 
 interface RoundProps {
-  state: State;
+	state: State;
 }
 
 const Stats = ({ state }: RoundProps) => {
-  const totalRequests = state.players.reduce(
-    (acc, player) => acc + player.log.length,
-    0
-  );
+	const totalRequests = state.players.reduce(
+		(acc, player) => acc + player.log.length,
+		0,
+	);
 
-  return (
-    <div id="counter" class="stats stats-horizontal text-2xl max-w-full">
-      <div class="stat place-items-center">
-        <span class="stat-title">Game</span>
-        <span class="stat-value font-mono">
-          <cmc-counter
-            count={state.status === "playing" ? "true" : "false"}
-            date-time={state.gameStartedAt}
-          />
-        </span>
-      </div>
-      <div class="stat place-items-center">
-        <span class="stat-title">Round</span>
-        <span class="stat-value font-mono">
-          <cmc-counter
-            count={state.status === "playing" ? "true" : "false"}
-            date-time={state.roundStartedAt}
-          />
-        </span>
-      </div>
-      <div class="stat place-items-center">
-        <span class="stat-title">Players</span>
-        <span class="stat-value font-mono">{state.players.length}</span>
-      </div>
-      <div class="stat place-items-center">
-        <span class="stat-title">Total requests</span>
-        <span
-          class="stat-value font-mono"
-          hx-swap="innerHTML"
-          sse-swap="request-count"
-        >
-          {totalRequests}
-        </span>
-      </div>
-    </div>
-  );
+	return (
+		<div id="counter" class="stats stats-horizontal text-2xl max-w-full">
+			<div class="stat place-items-center">
+				<span class="stat-title">Game</span>
+				<span class="stat-value font-mono">
+					<cmc-counter
+						count={state.status === "playing" ? "true" : "false"}
+						date-time={state.gameStartedAt}
+					/>
+				</span>
+			</div>
+			<div class="stat place-items-center">
+				<span class="stat-title">Round</span>
+				<span class="stat-value font-mono">
+					<cmc-counter
+						count={state.status === "playing" ? "true" : "false"}
+						date-time={state.roundStartedAt}
+					/>
+				</span>
+			</div>
+			<div class="stat place-items-center">
+				<span class="stat-title">Players</span>
+				<span class="stat-value font-mono">{state.players.length}</span>
+			</div>
+			<div class="stat place-items-center">
+				<span class="stat-title">Total requests</span>
+				<span
+					class="stat-value font-mono"
+					hx-swap="innerHTML"
+					sse-swap="request-count"
+				>
+					{totalRequests}
+				</span>
+			</div>
+		</div>
+	);
 };
 
 const PlayOrStop = ({ state }: RoundProps) => {
-  const { status } = state;
+	const { status } = state;
 
-  return (
-    <form class="flex flex-row gap-8" method="POST" action="">
-      {status === "stopped" ? (
-        <>
-          <div class="flex flex-row gap-2">
-            <button
-              type="submit"
-              formmethod="POST"
-              formaction="/admin/start-game?mode=demo"
-              class="btn btn-outline btn-warning"
-            >
-              Start Demo
-            </button>
-            <button
-              type="submit"
-              formmethod="POST"
-              formaction="/admin/start-game?mode=game"
-              class="btn btn-outline btn-success"
-            >
-              Start Game
-            </button>
-          </div>
-          <div class="flex flex-row gap-2">
-            <button
-              type="submit"
-              formmethod="POST"
-              formaction="/admin/reset-game"
-              class="btn btn-outline btn-error"
-            >
-              Reset Game
-            </button>
-            <button
-              type="submit"
-              formmethod="POST"
-              formaction="/admin/reset-state"
-              class="btn btn-outline btn-error"
-            >
-              Reset Server
-            </button>
-          </div>
-        </>
-      ) : null}
-      {status === "playing" ? (
-        <>
-          <button
-            type="submit"
-            formaction="/admin/pause-game"
-            class="btn btn-outline btn-warning"
-          >
-            Pause Game
-          </button>
-          <button
-            type="submit"
-            formaction="/admin/stop-game"
-            class="btn btn-outline btn-error"
-          >
-            Stop Game
-          </button>
-        </>
-      ) : null}
-      {status === "paused" ? (
-        <button
-          type="submit"
-          formaction="/admin/continue-game"
-          class="btn btn-outline btn-success"
-        >
-          Continue Game
-        </button>
-      ) : null}
-    </form>
-  );
+	return (
+		<form class="flex flex-row gap-8" method="POST" action="">
+			{status === "stopped" ? (
+				<>
+					<div class="flex flex-row gap-2">
+						<button
+							type="submit"
+							formmethod="POST"
+							formaction="/admin/start-game?mode=demo"
+							class="btn btn-outline btn-warning"
+						>
+							Start Demo
+						</button>
+						<button
+							type="submit"
+							formmethod="POST"
+							formaction="/admin/start-game?mode=game"
+							class="btn btn-outline btn-success"
+						>
+							Start Game
+						</button>
+					</div>
+					<div class="flex flex-row gap-2">
+						<button
+							type="submit"
+							formmethod="POST"
+							formaction="/admin/reset-game"
+							class="btn btn-outline btn-error"
+						>
+							Reset Game
+						</button>
+						<button
+							type="submit"
+							formmethod="POST"
+							formaction="/admin/reset-state"
+							class="btn btn-outline btn-error"
+						>
+							Reset Server
+						</button>
+					</div>
+				</>
+			) : null}
+			{status === "playing" ? (
+				<>
+					<button
+						type="submit"
+						formaction="/admin/pause-game"
+						class="btn btn-outline btn-warning"
+					>
+						Pause Game
+					</button>
+					<button
+						type="submit"
+						formaction="/admin/stop-game"
+						class="btn btn-outline btn-error"
+					>
+						Stop Game
+					</button>
+				</>
+			) : null}
+			{status === "paused" ? (
+				<button
+					type="submit"
+					formaction="/admin/continue-game"
+					class="btn btn-outline btn-success"
+				>
+					Continue Game
+				</button>
+			) : null}
+		</form>
+	);
 };
 
 const Round = ({ state }: RoundProps) => {
-  const { round, status, mode } = state;
-  const total = mode === "demo" ? 1 : Math.floor(gameQuestions.length / 2);
-  return (
-    <div class="rounded-lg flex flex-col gap-4 justify-items-center">
-      <div class="flex flex-row justify-between items-center">
-        <div class="flex flex-row">
-          <PlayOrStop state={state} />
-        </div>
-        <p class="text-center text-2xl">
-          Round {status === "stopped" ? 0 : round}
-          &nbsp;of&nbsp;
-          {total}
-        </p>
-        <form class="" hx-trigger="click">
-          <div class="flex flex-row join gap-[1px]">
-            <button
-              class="join-item btn btn-outline btn-error"
-              type="submit"
-              action="/admin/previous-round"
-              disabled={status === "stopped" || round === 0}
-              hx-post="/admin/previous-round"
-            >
-              Previous Round
-            </button>
+	const { round, status, mode } = state;
+	const total = mode === "demo" ? 1 : Math.floor(gameQuestions.length / 2);
+	return (
+		<div class="rounded-lg flex flex-col gap-4 justify-items-center">
+			<div class="flex flex-row justify-between items-center">
+				<div class="flex flex-row">
+					<PlayOrStop state={state} />
+				</div>
+				<p class="text-center text-2xl">
+					Round {status === "stopped" ? 0 : round}
+					&nbsp;of&nbsp;
+					{total}
+				</p>
+				<form class="" hx-trigger="click">
+					<div class="flex flex-row join gap-[1px]">
+						<button
+							class="join-item btn btn-outline btn-error"
+							type="submit"
+							action="/admin/previous-round"
+							disabled={status === "stopped" || round === 0}
+							hx-post="/admin/previous-round"
+						>
+							Previous Round
+						</button>
 
-            <button
-              class="join-item btn btn-outline btn-success"
-              type="submit"
-              action="/admin/next-round"
-              disabled={status === "stopped" || round === total - 1}
-              hx-post="/admin/next-round"
-            >
-              Next Round
-            </button>
-          </div>
-        </form>
-      </div>
-      <progress
-        class="progress max-w-full progress-primary"
-        value={status === "stopped" ? 0 : round}
-        max={state.mode === "demo" ? 1 : total}
-      />
-    </div>
-  );
+						<button
+							class="join-item btn btn-outline btn-success"
+							type="submit"
+							action="/admin/next-round"
+							disabled={status === "stopped" || round === total - 1}
+							hx-post="/admin/next-round"
+						>
+							Next Round
+						</button>
+					</div>
+				</form>
+			</div>
+			<progress
+				class="progress max-w-full progress-primary"
+				value={status === "stopped" ? 0 : round}
+				max={state.mode === "demo" ? 1 : total}
+			/>
+		</div>
+	);
 };
 
 const PlayerRow = (player: Player) => {
-  const rowId = `player-${player.uuid}`;
-  return (
-    <tr class="odd:bg-base-300" id={rowId}>
-      <td>
-        <a
-          class="link link-hover"
-          href={`/players/${player.uuid}`}
-          hx-target="#content"
-          hx-swap="outerHTML"
-          hx-push-url="true"
-          safe
-        >
-          {player.nick}
-        </a>
-      </td>
-      <td safe>{player.url}</td>
-      <td sse-swap={`player-score-${player.uuid}`} hx-swap="innerHTML">
-        {player.log?.[0]?.score ?? 0}
-      </td>
-      <td>
-        {player.playing ? (
-          <span class="text-success">Playing</span>
-        ) : (
-          <span class="text-error">Not playing</span>
-        )}
-      </td>
-      <td>
-        <form
-          method="POST"
-          action="/admin/remove"
-          hx-post="/admin/remove"
-          hx-target={`#${rowId}`} // Replace row with (empty) hx response to remove it
-          hx-swap="outerHTML"
-        >
-          <input type="hidden" name="uuid" value={player.uuid} />
-          <button type="submit" class="btn btn-sm btn-outline btn-error">
-            Remove
-          </button>
-        </form>
-      </td>
-    </tr>
-  );
+	const rowId = `player-${player.uuid}`;
+	return (
+		<tr class="odd:bg-base-300" id={rowId}>
+			<td>
+				<a
+					class="link link-hover"
+					href={`/players/${player.uuid}`}
+					hx-target="#content"
+					hx-swap="outerHTML"
+					hx-push-url="true"
+					safe
+				>
+					{player.nick}
+				</a>
+			</td>
+			<td safe>{player.url}</td>
+			<td sse-swap={`player-score-${player.uuid}`} hx-swap="innerHTML">
+				{player.log?.[0]?.score ?? 0}
+			</td>
+			<td>
+				{player.playing ? (
+					<span class="text-success">Playing</span>
+				) : (
+					<span class="text-error">Not playing</span>
+				)}
+			</td>
+			<td>
+				<form
+					method="POST"
+					action="/admin/remove"
+					hx-post="/admin/remove"
+					hx-target={`#${rowId}`} // Replace row with (empty) hx response to remove it
+					hx-swap="outerHTML"
+				>
+					<input type="hidden" name="uuid" value={player.uuid} />
+					<button type="submit" class="btn btn-sm btn-outline btn-error">
+						Remove
+					</button>
+				</form>
+			</td>
+		</tr>
+	);
 };
 
 interface AdminProps {
-  state: State;
+	state: State;
 }
 
 const Admin = ({ state }: AdminProps) => {
-  return (
-    <div
-      id="content"
-      class="epic pt-8 flex flex-col min-w-full max-w-full gap-8"
-      hx-ext="sse"
-      sse-connect="/admin/sse"
-    >
-      {/* Display round */}
-      <div class="flex flex-col gap-8 z-10 bg-base-100 bg-opacity-90 backdrop-blur-sm p-8 rounded-2xl">
-        <Round state={state} />
-        <Stats state={state} />
-      </div>
-      <div class="z-10 bg-base-100 bg-opacity-90 backdrop-blur-sm p-8 rounded-2xl">
-        <h2 class="hidden">Players</h2>
-        <div class="overflow-x-auto max-w-full h-full">
-          <table class="table text-">
-            <thead>
-              <tr>
-                <th>Nick</th>
-                <th>URL</th>
-                <th>Score</th>
-                <th>Status</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody
-              class="auto-animate"
-              sse-swap="player-joined"
-              hx-swap="afterbegin"
-            >
-              {state.players
-                .toSorted((a, b) => a.score - b.score)
-                .map((player) => (
-                  // biome-ignore lint/correctness/useJsxKeyInIterable: Don't need it here
-                  <PlayerRow {...player} />
-                ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-  );
+	return (
+		<div
+			id="content"
+			class="epic pt-8 flex flex-col min-w-full max-w-full gap-8"
+			hx-ext="sse"
+			sse-connect="/admin/sse"
+		>
+			{/* Display round */}
+			<div class="flex flex-col gap-8 z-10 bg-base-100 bg-opacity-90 backdrop-blur-sm p-8 rounded-2xl">
+				<Round state={state} />
+				<Stats state={state} />
+			</div>
+			<div class="z-10 bg-base-100 bg-opacity-90 backdrop-blur-sm p-8 rounded-2xl">
+				<h2 class="hidden">Players</h2>
+				<div class="overflow-x-auto max-w-full h-full">
+					<table class="table text-">
+						<thead>
+							<tr>
+								<th>Nick</th>
+								<th>URL</th>
+								<th>Score</th>
+								<th>Status</th>
+								<th />
+							</tr>
+						</thead>
+						<tbody
+							class="auto-animate"
+							sse-swap="player-joined"
+							hx-swap="afterbegin"
+						>
+							{state.players
+								.toSorted((a, b) => a.score - b.score)
+								.map((player) => (
+									// biome-ignore lint/correctness/useJsxKeyInIterable: Don't need it here
+									<PlayerRow {...player} />
+								))}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export const plugin = basePluginSetup()
-  .get("/admin", ({ htmx, cookie: { user }, store: { state } }) => {
-    const header = (
-      <div class="">
-        <a href="/admin/logout" class="btn btn-ghost" hx-push-url="true">
-          Logout
-        </a>
-      </div>
-    );
+	.get("/admin", ({ htmx, cookie: { user }, store: { state } }) => {
+		const header = (
+			<div class="">
+				<a href="/admin/logout" class="btn btn-ghost" hx-push-url="true">
+					Logout
+				</a>
+			</div>
+		);
 
-    if (user.value === "admin") {
-      const Layout = htmx.is ? HXLayout : HTMLLayout;
-      return (
-        <Layout page="Admin" header={header}>
-          <Admin state={state} />
-        </Layout>
-      );
-    }
-    const Layout = htmx.is ? HXLayout : HTMLLayout;
-    return (
-      <Layout page="Sign Up" header={header}>
-        <AdminLoginForm fieldErrors={{}} />
-      </Layout>
-    );
-  })
-  .post(
-    "/admin/login",
-    ({ body: { secret }, htmx, set, cookie: { user } }) => {
-      const fieldErrors: Record<string, string> = {};
+		if (user.value === "admin") {
+			const Layout = htmx.is ? HXLayout : HTMLLayout;
+			return (
+				<Layout page="Admin" header={header}>
+					<Admin state={state} />
+				</Layout>
+			);
+		}
+		const Layout = htmx.is ? HXLayout : HTMLLayout;
+		return (
+			<Layout page="Sign Up" header={header}>
+				<AdminLoginForm fieldErrors={{}} />
+			</Layout>
+		);
+	})
+	.post(
+		"/admin/login",
+		({ body: { secret }, htmx, set, cookie: { user } }) => {
+			const fieldErrors: Record<string, string> = {};
 
-      // biome-ignore lint/complexity/useLiteralKeys: Bun.env is a record of unknown keys
-      if (secret !== Bun.env["CMC_SECRET"]) {
-        fieldErrors["/secret"] = "Invalid secret";
-      } else {
-        user.set({
-          value: "admin",
-          expires: new Date(Date.now() + 1000 * 60 * 60),
-          httpOnly: true,
-        });
-      }
+			// biome-ignore lint/complexity/useLiteralKeys: Bun.env is a record of unknown keys
+			if (secret !== Bun.env["CMC_SECRET"]) {
+				fieldErrors["/secret"] = "Invalid secret";
+			} else {
+				user.set({
+					value: "admin",
+					expires: new Date(Date.now() + 1000 * 60 * 60),
+					httpOnly: true,
+				});
+			}
 
-      if (Object.keys(fieldErrors).length) {
-        set.status = 400;
-        const Layout = htmx.is ? HXLayout : HTMLLayout;
-        return (
-          <Layout page="Admin">
-            <AdminLoginForm fieldErrors={fieldErrors} secret={""} />
-          </Layout>
-        );
-      }
+			if (Object.keys(fieldErrors).length) {
+				set.status = 400;
+				const Layout = htmx.is ? HXLayout : HTMLLayout;
+				return (
+					<Layout page="Admin">
+						<AdminLoginForm fieldErrors={fieldErrors} secret={""} />
+					</Layout>
+				);
+			}
 
-      if (htmx.is) {
-        htmx.redirect("/admin");
-      } else {
-        set.redirect = "/admin";
-      }
-    },
-    {
-      body: t.Object({
-        secret: t.String({}),
-      }),
-      error: ({ code, error, htmx, set }) => {
-        const Layout = htmx.is ? HXLayout : HTMLLayout;
-        if (code === "VALIDATION") {
-          set.status = 200;
-          const errors = mapValidationError(error as ValidationError);
-          return (
-            <Layout page="Admin">
-              <AdminLoginForm fieldErrors={errors} />
-            </Layout>
-          );
-        }
-        return (
-          <Layout page="Admin">
-            <AdminLoginForm fieldErrors={{}} />
-          </Layout>
-        );
-      },
-    }
-  )
-  .post(
-    "/admin/remove",
-    ({ body: { uuid }, htmx, set, store: { state } }) => {
-      removePlayer(state, uuid);
-      if (htmx.is) {
-        htmx.location({ path: "/admin", target: "#main" });
-      } else {
-        set.redirect = "/admin";
-        return <></>;
-      }
-    },
-    {
-      body: t.Object({
-        uuid: t.String(),
-      }),
-    }
-  )
-  .post(
-    "/admin/start-game",
-    ({ set, store: { state }, query: { mode } }) => {
-      startGame(state, mode);
-      set.redirect = "/admin";
-    },
-    {
-      query: t.Object({
-        mode: t.Union([t.Literal("demo"), t.Literal("game")]),
-      }),
-    }
-  )
-  .post("/admin/stop-game", ({ htmx, set, store: { state } }) => {
-    const Layout = htmx.is ? HXLayout : HTMLLayout;
-    stopGame(state);
+			if (htmx.is) {
+				htmx.redirect("/admin");
+			} else {
+				set.redirect = "/admin";
+			}
+		},
+		{
+			body: t.Object({
+				secret: t.String({}),
+			}),
+			error: ({ code, error, htmx, set }) => {
+				const Layout = htmx.is ? HXLayout : HTMLLayout;
+				if (code === "VALIDATION") {
+					set.status = 200;
+					const errors = mapValidationError(error as ValidationError);
+					return (
+						<Layout page="Admin">
+							<AdminLoginForm fieldErrors={errors} />
+						</Layout>
+					);
+				}
+				return (
+					<Layout page="Admin">
+						<AdminLoginForm fieldErrors={{}} />
+					</Layout>
+				);
+			},
+		},
+	)
+	.post(
+		"/admin/remove",
+		({ body: { uuid }, htmx, set, store: { state } }) => {
+			removePlayer(state, uuid);
+			if (htmx.is) {
+				htmx.location({ path: "/admin", target: "#main" });
+			} else {
+				set.redirect = "/admin";
+				return <></>;
+			}
+		},
+		{
+			body: t.Object({
+				uuid: t.String(),
+			}),
+		},
+	)
+	.post(
+		"/admin/start-game",
+		({ set, store: { state }, query: { mode } }) => {
+			startGame(state, mode);
+			set.redirect = "/admin";
+		},
+		{
+			query: t.Object({
+				mode: t.Union([t.Literal("demo"), t.Literal("game")]),
+			}),
+		},
+	)
+	.post("/admin/stop-game", ({ htmx, set, store: { state } }) => {
+		const Layout = htmx.is ? HXLayout : HTMLLayout;
+		stopGame(state);
 
-    if (htmx.is) {
-      return (
-        <Layout page="Admin">
-          <PlayOrStop state={state} />
-        </Layout>
-      );
-    }
+		if (htmx.is) {
+			return (
+				<Layout page="Admin">
+					<PlayOrStop state={state} />
+				</Layout>
+			);
+		}
 
-    set.redirect = "/admin";
-  })
-  .post("/admin/pause-game", ({ htmx, set, store: { state } }) => {
-    pauseGame(state);
+		set.redirect = "/admin";
+	})
+	.post("/admin/pause-game", ({ htmx, set, store: { state } }) => {
+		pauseGame(state);
 
-    if (htmx.is) {
-      htmx.location({ path: "/admin", target: "#main" });
-    } else {
-      set.redirect = "/admin";
-    }
-  })
-  .post("/admin/continue-game", ({ htmx, set, store: { state } }) => {
-    continueGame(state);
+		if (htmx.is) {
+			htmx.location({ path: "/admin", target: "#main" });
+		} else {
+			set.redirect = "/admin";
+		}
+	})
+	.post("/admin/continue-game", ({ htmx, set, store: { state } }) => {
+		continueGame(state);
 
-    if (htmx.is) {
-      htmx.location({ path: "/admin", target: "#main" });
-    } else {
-      set.redirect = "/admin";
-    }
-  })
-  .post("/admin/reset-game", ({ htmx, set, store: { state } }) => {
-    resetGame(state);
+		if (htmx.is) {
+			htmx.location({ path: "/admin", target: "#main" });
+		} else {
+			set.redirect = "/admin";
+		}
+	})
+	.post("/admin/reset-game", ({ htmx, set, store: { state } }) => {
+		resetGame(state);
 
-    if (htmx.is) {
-      htmx.location({ path: "/admin", target: "#main" });
-    } else {
-      set.redirect = "/admin";
-    }
-  })
-  .post("/admin/next-round", ({ htmx, set, store: { state } }) => {
-    nextRound(state);
+		if (htmx.is) {
+			htmx.location({ path: "/admin", target: "#main" });
+		} else {
+			set.redirect = "/admin";
+		}
+	})
+	.post("/admin/next-round", ({ htmx, set, store: { state } }) => {
+		nextRound(state);
 
-    if (htmx.is) {
-      htmx.location({ path: "/admin", target: "#main" });
-    } else {
-      set.redirect = "/admin";
-    }
-  })
-  .post("/admin/previous-round", ({ htmx, set, store: { state } }) => {
-    previousRound(state);
+		if (htmx.is) {
+			htmx.location({ path: "/admin", target: "#main" });
+		} else {
+			set.redirect = "/admin";
+		}
+	})
+	.post("/admin/previous-round", ({ htmx, set, store: { state } }) => {
+		previousRound(state);
 
-    if (htmx.is) {
-      htmx.location({ path: "/admin", target: "#main" });
-    } else {
-      set.redirect = "/admin";
-    }
-  })
-  .get("/admin/sse", ({ store: { state }, request }) => {
-    const stream = createSSEResponse(state, request, [
-      (state, event) => {
-        if (event.type === "player-answer") {
-          const player = state.players.find((p) => p.uuid === event.uuid);
-          return player
-            ? [
-                {
-                  event: `player-score-${player.uuid}`,
-                  data: `${event.log.score}`,
-                },
-                {
-                  event: "request-count",
-                  data: `${state.players.reduce(
-                    (acc, p) => acc + p.log.length,
-                    0
-                  )}`,
-                },
-              ]
-            : [];
-        }
+		if (htmx.is) {
+			htmx.location({ path: "/admin", target: "#main" });
+		} else {
+			set.redirect = "/admin";
+		}
+	})
+	.get("/admin/sse", ({ store: { state }, request }) => {
+		const stream = createSSEResponse(state, request, [
+			(state, event) => {
+				if (event.type === "player-answer") {
+					const player = state.players.find((p) => p.uuid === event.uuid);
+					return player
+						? [
+								{
+									event: `player-score-${player.uuid}`,
+									data: `${event.log.score}`,
+								},
+								{
+									event: "request-count",
+									data: `${state.players.reduce(
+										(acc, p) => acc + p.log.length,
+										0,
+									)}`,
+								},
+							]
+						: [];
+				}
 
-        if (event.type === "player-joined") {
-          return [
-            {
-              event: "player-joined",
-              data: `${(<PlayerRow {...event} />)}`,
-            },
-          ];
-        }
-        return [];
-      },
-    ]);
+				if (event.type === "player-joined") {
+					return [
+						{
+							event: "player-joined",
+							data: `${<PlayerRow {...event} />}`,
+						},
+					];
+				}
+				return [];
+			},
+		]);
 
-    return stream;
-  });
+		return stream;
+	});

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -2,47 +2,47 @@ import { HTMLLayout } from "../../layouts/main";
 import { basePluginSetup } from "../../plugins";
 
 export const plugin = basePluginSetup().get("/", ({ set }) => {
-  const header = (
-    <nav hx-target="#main">
-      <a class="btn btn-ghost" href="/scoreboard" hx-push-url="true">
-        Scoreboard
-      </a>
-      <a href="/admin" class="btn btn-ghost" hx-push-url="true">
-        Admin
-      </a>
-    </nav>
-  );
-  return (
-    <HTMLLayout page="Home" header={header}>
-      <div
-        class="epic min-w-full max-h-full flex flex-col grow items-center justify-center prose"
-        hx-target="#main"
-      >
-        <div class="z-10 flex flex-col prose items-center text-center justify-center">
-          <h1 class="mb-5 text-5xl font-bold">
-            <img
-              class="rounded-2xl shadow-xl m-0"
-              src="/public/code-monkey-clash-landing-image.webp"
-              alt="Code Monkey Clash"
-            />
-          </h1>
-          <div class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm">
-            <p class="mb-5 text-xl">
-              Welcome to Code Monkey Clash, a game inspired by Extreme Startup
-              hackathon. Compete against other players to see who can solve code
-              puzzles the fastest.
-            </p>
-            <div class="flex flex-row gap-4 w-full justify-center">
-              <a class="btn btn-primary" href="/signup" hx-push-url="true">
-                Get Started
-              </a>
-              <a class="btn btn-ghost" href="/scoreboard" hx-push-url="true">
-                Scoreboard
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
-    </HTMLLayout>
-  );
+	const header = (
+		<nav hx-target="#main">
+			<a class="btn btn-ghost" href="/scoreboard" hx-push-url="true">
+				Scoreboard
+			</a>
+			<a href="/admin" class="btn btn-ghost" hx-push-url="true">
+				Admin
+			</a>
+		</nav>
+	);
+	return (
+		<HTMLLayout page="Home" header={header}>
+			<div
+				class="epic min-w-full max-h-full flex flex-col grow items-center justify-center prose"
+				hx-target="#main"
+			>
+				<div class="z-10 flex flex-col prose items-center text-center justify-center">
+					<h1 class="mb-5 text-5xl font-bold">
+						<img
+							class="rounded-2xl shadow-xl m-0"
+							src="/public/code-monkey-clash-landing-image.webp"
+							alt="Code Monkey Clash"
+						/>
+					</h1>
+					<div class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm">
+						<p class="mb-5 text-xl">
+							Welcome to Code Monkey Clash, a game inspired by Extreme Startup
+							hackathon. Compete against other players to see who can solve code
+							puzzles the fastest.
+						</p>
+						<div class="flex flex-row gap-4 w-full justify-center">
+							<a class="btn btn-primary" href="/signup" hx-push-url="true">
+								Get Started
+							</a>
+							<a class="btn btn-ghost" href="/scoreboard" hx-push-url="true">
+								Scoreboard
+							</a>
+						</div>
+					</div>
+				</div>
+			</div>
+		</HTMLLayout>
+	);
 });

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -2,48 +2,47 @@ import { HTMLLayout } from "../../layouts/main";
 import { basePluginSetup } from "../../plugins";
 
 export const plugin = basePluginSetup().get("/", ({ set }) => {
-	const header = (
-		<nav hx-boost="true" hx-target="#main">
-			<a class="btn btn-ghost" href="/scoreboard">
-				Scoreboard
-			</a>
-			<a href="/admin" class="btn btn-ghost">
-				Admin
-			</a>
-		</nav>
-	);
-	return (
-		<HTMLLayout page="Home" header={header}>
-			<div
-				class="epic min-w-full max-h-full flex flex-col grow items-center justify-center prose"
-				hx-boost="true"
-				hx-target="#main"
-			>
-				<div class="z-10 flex flex-col prose items-center text-center justify-center">
-					<h1 class="mb-5 text-5xl font-bold">
-						<img
-							class="rounded-2xl shadow-xl m-0"
-							src="/public/code-monkey-clash-landing-image.webp"
-							alt="Code Monkey Clash"
-						/>
-					</h1>
-					<div class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm">
-						<p class="mb-5 text-xl">
-							Welcome to Code Monkey Clash, a game inspired by Extreme Startup
-							hackathon. Compete against other players to see who can solve code
-							puzzles the fastest.
-						</p>
-						<div class="flex flex-row gap-4 w-full justify-center">
-							<a class="btn btn-primary" href="/signup">
-								Get Started
-							</a>
-							<a class="btn btn-ghost" href="/scoreboard">
-								Scoreboard
-							</a>
-						</div>
-					</div>
-				</div>
-			</div>
-		</HTMLLayout>
-	);
+  const header = (
+    <nav hx-target="#main">
+      <a class="btn btn-ghost" href="/scoreboard" hx-push-url="true">
+        Scoreboard
+      </a>
+      <a href="/admin" class="btn btn-ghost" hx-push-url="true">
+        Admin
+      </a>
+    </nav>
+  );
+  return (
+    <HTMLLayout page="Home" header={header}>
+      <div
+        class="epic min-w-full max-h-full flex flex-col grow items-center justify-center prose"
+        hx-target="#main"
+      >
+        <div class="z-10 flex flex-col prose items-center text-center justify-center">
+          <h1 class="mb-5 text-5xl font-bold">
+            <img
+              class="rounded-2xl shadow-xl m-0"
+              src="/public/code-monkey-clash-landing-image.webp"
+              alt="Code Monkey Clash"
+            />
+          </h1>
+          <div class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm">
+            <p class="mb-5 text-xl">
+              Welcome to Code Monkey Clash, a game inspired by Extreme Startup
+              hackathon. Compete against other players to see who can solve code
+              puzzles the fastest.
+            </p>
+            <div class="flex flex-row gap-4 w-full justify-center">
+              <a class="btn btn-primary" href="/signup" hx-push-url="true">
+                Get Started
+              </a>
+              <a class="btn btn-ghost" href="/scoreboard" hx-push-url="true">
+                Scoreboard
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </HTMLLayout>
+  );
 });

--- a/src/pages/not-found/not-found.tsx
+++ b/src/pages/not-found/not-found.tsx
@@ -2,33 +2,33 @@ import { HTMLLayout } from "../../layouts/main";
 import { basePluginSetup } from "../../plugins";
 
 export const notFoundPlugin = basePluginSetup().all("*", () => {
-  const header = (
-    <nav hx-boost="true" hx-target="#main">
-      <a href="/admin" class="btn">
-        Admin
-      </a>
-    </nav>
-  );
-  return (
-    <HTMLLayout page="Home" header={header}>
-      <div
-        class="epic min-w-full max-h-full flex flex-col grow items-center justify-center prose"
-        hx-target="#main"
-      >
-        <div class="z-10 flex flex-col gap-5 prose items-center text-center justify-center">
-          <div class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm w-full">
-            <h1 class="mb-5 text-5xl font-bold">404 - Not Found</h1>
-            <a class="btn btn-primary" href="/signup" hx-push-url="true">
-              Get Started
-            </a>
-          </div>
-          <img
-            class="rounded-2xl shadow-xl m-0"
-            src="/public/code-monkey-clash-landing-image.webp"
-            alt="Code Monkey Clash"
-          />
-        </div>
-      </div>
-    </HTMLLayout>
-  );
+	const header = (
+		<nav hx-boost="true" hx-target="#main">
+			<a href="/admin" class="btn">
+				Admin
+			</a>
+		</nav>
+	);
+	return (
+		<HTMLLayout page="Home" header={header}>
+			<div
+				class="epic min-w-full max-h-full flex flex-col grow items-center justify-center prose"
+				hx-target="#main"
+			>
+				<div class="z-10 flex flex-col gap-5 prose items-center text-center justify-center">
+					<div class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm w-full">
+						<h1 class="mb-5 text-5xl font-bold">404 - Not Found</h1>
+						<a class="btn btn-primary" href="/signup" hx-push-url="true">
+							Get Started
+						</a>
+					</div>
+					<img
+						class="rounded-2xl shadow-xl m-0"
+						src="/public/code-monkey-clash-landing-image.webp"
+						alt="Code Monkey Clash"
+					/>
+				</div>
+			</div>
+		</HTMLLayout>
+	);
 });

--- a/src/pages/not-found/not-found.tsx
+++ b/src/pages/not-found/not-found.tsx
@@ -2,34 +2,33 @@ import { HTMLLayout } from "../../layouts/main";
 import { basePluginSetup } from "../../plugins";
 
 export const notFoundPlugin = basePluginSetup().all("*", () => {
-	const header = (
-		<nav hx-boost="true" hx-target="#main">
-			<a href="/admin" class="btn">
-				Admin
-			</a>
-		</nav>
-	);
-	return (
-		<HTMLLayout page="Home" header={header}>
-			<div
-				class="epic min-w-full max-h-full flex flex-col grow items-center justify-center prose"
-				hx-boost="true"
-				hx-target="#main"
-			>
-				<div class="z-10 flex flex-col gap-5 prose items-center text-center justify-center">
-					<div class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm w-full">
-						<h1 class="mb-5 text-5xl font-bold">404 - Not Found</h1>
-						<a class="btn btn-primary" href="/signup">
-							Get Started
-						</a>
-					</div>
-					<img
-						class="rounded-2xl shadow-xl m-0"
-						src="/public/code-monkey-clash-landing-image.webp"
-						alt="Code Monkey Clash"
-					/>
-				</div>
-			</div>
-		</HTMLLayout>
-	);
+  const header = (
+    <nav hx-boost="true" hx-target="#main">
+      <a href="/admin" class="btn">
+        Admin
+      </a>
+    </nav>
+  );
+  return (
+    <HTMLLayout page="Home" header={header}>
+      <div
+        class="epic min-w-full max-h-full flex flex-col grow items-center justify-center prose"
+        hx-target="#main"
+      >
+        <div class="z-10 flex flex-col gap-5 prose items-center text-center justify-center">
+          <div class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm w-full">
+            <h1 class="mb-5 text-5xl font-bold">404 - Not Found</h1>
+            <a class="btn btn-primary" href="/signup" hx-push-url="true">
+              Get Started
+            </a>
+          </div>
+          <img
+            class="rounded-2xl shadow-xl m-0"
+            src="/public/code-monkey-clash-landing-image.webp"
+            alt="Code Monkey Clash"
+          />
+        </div>
+      </div>
+    </HTMLLayout>
+  );
 });

--- a/src/pages/player.tsx
+++ b/src/pages/player.tsx
@@ -1,239 +1,239 @@
 import { t } from "elysia";
 import { escape as htmlEscape } from "html-escaper";
-import { HTMLLayout, HXLayout } from "../layouts/main";
-import { basePluginSetup } from "../plugins";
 import {
-  type Player,
-  type State,
-  type PlayerLog,
-  playerSurrender,
+	type Player,
+	type PlayerLog,
+	type State,
+	playerSurrender,
 } from "../game/state";
+import { HTMLLayout, HXLayout } from "../layouts/main";
 import { createSSEResponse } from "../middleware/sse/sse";
+import { basePluginSetup } from "../plugins";
 
 interface PlayerLayoutProps {
-  state: State;
-  player: Player;
+	state: State;
+	player: Player;
 }
 
 interface PlayerStatsProps extends PlayerLayoutProps {
-  log?: PlayerLog;
+	log?: PlayerLog;
 }
 
 const PlayerStats = ({ state, player, log }: PlayerStatsProps) => {
-  const { round } = state;
+	const { round } = state;
 
-  return (
-    <div
-      id="counter"
-      class="rounded-2xl z-10 bg-base-100 bg-opacity-80 backdrop-blur-sm drop-shadow-lg stats stats-horizontal text-2xl max-w-full"
-      sse-swap="stats"
-      hx-swap="outerHTML"
-    >
-      <div class="stat place-items-center">
-        <span class="stat-title">Nick</span>
-        <span class="stat-value" safe>
-          {player.nick}
-        </span>
-      </div>
-      <div class="stat place-items-center">
-        <span class="stat-title">Round</span>
-        <span class="stat-value">{round}</span>
-      </div>
-      <div class="stat place-items-center">
-        <span class="stat-title">Score</span>
-        <span class="stat-value">{log?.score ?? 0}</span>
-      </div>
-      <div class="stat place-items-center">
-        <span class="stat-title">Questions</span>
-        <span class="stat-value">{log?.id ?? 0}</span>
-      </div>
-      <div class="stat place-items-center">
-        <span class="stat-title">Answer ratio</span>
-        <span class="stat-value" safe>
-          {Number.isNaN(log?.answerRatio ?? 0)
-            ? "N/A"
-            : log?.answerRatio?.toPrecision(2)}
-        </span>
-      </div>
-    </div>
-  );
+	return (
+		<div
+			id="counter"
+			class="rounded-2xl z-10 bg-base-100 bg-opacity-80 backdrop-blur-sm drop-shadow-lg stats stats-horizontal text-2xl max-w-full"
+			sse-swap="stats"
+			hx-swap="outerHTML"
+		>
+			<div class="stat place-items-center">
+				<span class="stat-title">Nick</span>
+				<span class="stat-value" safe>
+					{player.nick}
+				</span>
+			</div>
+			<div class="stat place-items-center">
+				<span class="stat-title">Round</span>
+				<span class="stat-value">{round}</span>
+			</div>
+			<div class="stat place-items-center">
+				<span class="stat-title">Score</span>
+				<span class="stat-value">{log?.score ?? 0}</span>
+			</div>
+			<div class="stat place-items-center">
+				<span class="stat-title">Questions</span>
+				<span class="stat-value">{log?.id ?? 0}</span>
+			</div>
+			<div class="stat place-items-center">
+				<span class="stat-title">Answer ratio</span>
+				<span class="stat-value" safe>
+					{Number.isNaN(log?.answerRatio ?? 0)
+						? "N/A"
+						: log?.answerRatio?.toPrecision(2)}
+				</span>
+			</div>
+		</div>
+	);
 };
 
 export const PlayerControl = ({ player }: { player: Player }) => {
-  return (
-    <form
-      class="z-10 flex flex-row items-center"
-      method="POST"
-      action={`/players/${player.uuid}/surrender`}
-    >
-      {player.playing ? (
-        <button
-          class="btn btn-outline btn-error"
-          type="submit"
-          hx-post={`/players/${player.uuid}/surrender`}
-          hx-swap="outerHTML"
-        >
-          Surrender
-        </button>
-      ) : (
-        <button
-          class="btn btn-outline btn-success"
-          type="submit"
-          hx-post={`/players/${player.uuid}/play`}
-          hx-swap="outerHTML"
-        >
-          Rejoin
-        </button>
-      )}
-    </form>
-  );
+	return (
+		<form
+			class="z-10 flex flex-row items-center"
+			method="POST"
+			action={`/players/${player.uuid}/surrender`}
+		>
+			{player.playing ? (
+				<button
+					class="btn btn-outline btn-error"
+					type="submit"
+					hx-post={`/players/${player.uuid}/surrender`}
+					hx-swap="outerHTML"
+				>
+					Surrender
+				</button>
+			) : (
+				<button
+					class="btn btn-outline btn-success"
+					type="submit"
+					hx-post={`/players/${player.uuid}/play`}
+					hx-swap="outerHTML"
+				>
+					Rejoin
+				</button>
+			)}
+		</form>
+	);
 };
 
 const QuestionTableRow = ({ log }: { log: PlayerLog }) => {
-  return (
-    <tr
-      class="odd:bg-base-300"
-      id={`log-${log.id}`}
-      hx-swap="outerHTML"
-      sse-swap={`log-update-${log.id}`}
-    >
-      <th safe>{new Date(log.date).toLocaleTimeString()}</th>
-      <td safe>{log.question}</td>
-      <td>
-        {log.answer ? (
-          <span
-            safe
-            class={`${log.points > 0 ? "text-success" : "text-error"}`}
-          >
-            {htmlEscape(log.answer).substring(0, 500)}
-          </span>
-        ) : (
-          "N/A"
-        )}
-      </td>
-      <td>{log.statusCode ?? "N/A"}</td>
-      <td>{log.error ? <span class="text-error">{log.error}</span> : null}</td>
-      <td>{(log.questionInterval ?? 0) / 1000}</td>
-      <td>{log.points}</td>
-      <td>{log.score}</td>
-    </tr>
-  );
+	return (
+		<tr
+			class="odd:bg-base-300"
+			id={`log-${log.id}`}
+			hx-swap="outerHTML"
+			sse-swap={`log-update-${log.id}`}
+		>
+			<th safe>{new Date(log.date).toLocaleTimeString()}</th>
+			<td safe>{log.question}</td>
+			<td>
+				{log.answer ? (
+					<span
+						safe
+						class={`${log.points > 0 ? "text-success" : "text-error"}`}
+					>
+						{htmlEscape(log.answer).substring(0, 500)}
+					</span>
+				) : (
+					"N/A"
+				)}
+			</td>
+			<td>{log.statusCode ?? "N/A"}</td>
+			<td>{log.error ? <span class="text-error">{log.error}</span> : null}</td>
+			<td>{(log.questionInterval ?? 0) / 1000}</td>
+			<td>{log.points}</td>
+			<td>{log.score}</td>
+		</tr>
+	);
 };
 
 const QuestionTable = (player: Player) => {
-  return (
-    <div class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm drop-shadow-lg flex flex-col grow overflow-x-auto min-h-full">
-      <table class="table">
-        <thead>
-          <tr>
-            <th>Time</th>
-            <th>Question</th>
-            <th>Answer</th>
-            <th>HTTP</th>
-            <th>Error</th>
-            <th>Question rate</th>
-            <th>Points</th>
-            <th>Score</th>
-          </tr>
-        </thead>
-        <tbody class="auto-animate" sse-swap="log" hx-swap="afterbegin">
-          {
-            // For performance reasons, only show the last 50 logs
-            player.log.slice(0, 50).map((log) => (
-              // biome-ignore lint/correctness/useJsxKeyInIterable: <explanation>
-              <QuestionTableRow log={log} />
-            ))
-          }
-        </tbody>
-      </table>
-    </div>
-  );
+	return (
+		<div class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm drop-shadow-lg flex flex-col grow overflow-x-auto min-h-full">
+			<table class="table">
+				<thead>
+					<tr>
+						<th>Time</th>
+						<th>Question</th>
+						<th>Answer</th>
+						<th>HTTP</th>
+						<th>Error</th>
+						<th>Question rate</th>
+						<th>Points</th>
+						<th>Score</th>
+					</tr>
+				</thead>
+				<tbody class="auto-animate" sse-swap="log" hx-swap="afterbegin">
+					{
+						// For performance reasons, only show the last 50 logs
+						player.log
+							.slice(0, 50)
+							.map((log) => (
+								// biome-ignore lint/correctness/useJsxKeyInIterable: <explanation>
+								<QuestionTableRow log={log} />
+							))
+					}
+				</tbody>
+			</table>
+		</div>
+	);
 };
 
 export const PlayerLayout = ({ player, state }: PlayerLayoutProps) => {
-  return (
-    <div
-      class="epic flex flex-col grow gap-8 pt-8"
-      hx-ext="sse"
-      sse-connect={`/players/${player.uuid}/sse`}
-    >
-      <PlayerStats player={player} state={state} log={player.log[0]} />
-      <QuestionTable {...player} />
-    </div>
-  );
+	return (
+		<div
+			class="epic flex flex-col grow gap-8 pt-8"
+			hx-ext="sse"
+			sse-connect={`/players/${player.uuid}/sse`}
+		>
+			<PlayerStats player={player} state={state} log={player.log[0]} />
+			<QuestionTable {...player} />
+		</div>
+	);
 };
 
 export const plugin = basePluginSetup()
-  .get(
-    "/players/:uuid",
-    ({ htmx, params: { uuid }, store: { state } }) => {
-      const Layout = htmx.is ? HXLayout : HTMLLayout;
-      const player = state.players.find((p) => p.uuid === uuid);
+	.get(
+		"/players/:uuid",
+		({ htmx, params: { uuid }, store: { state } }) => {
+			const Layout = htmx.is ? HXLayout : HTMLLayout;
+			const player = state.players.find((p) => p.uuid === uuid);
 
-      if (!player) {
-        return (
-          <Layout page="User">
-            <div class="flex flex-col">
-              <h1 class="">Player not found</h1>
-              <p>
-                <a class="link link-success" href="/signup" hx-push-url="true">
-                  Create a new player
-                </a>{" "}
-                to compete.
-              </p>
-            </div>
-          </Layout>
-        );
-      }
+			if (!player) {
+				return (
+					<Layout page="User">
+						<div class="flex flex-col">
+							<h1 class="">Player not found</h1>
+							<p>
+								<a class="link link-success" href="/signup" hx-push-url="true">
+									Create a new player
+								</a>{" "}
+								to compete.
+							</p>
+						</div>
+					</Layout>
+				);
+			}
 
-      return (
-        <Layout page="User" header={<PlayerControl player={player} />}>
-          <PlayerLayout state={state} player={player} />
-        </Layout>
-      );
-    },
-    {
-      params: t.Object({
-        uuid: t.String(),
-      }),
-    }
-  )
-  .post(
-    "/players/:uuid/surrender",
-    ({ params: { uuid }, store: { state } }) => {
-      playerSurrender(state, uuid);
-    }
-  )
-  .get(
-    "/players/:uuid/sse",
-    ({ params: { uuid }, set, store: { state }, request }) => {
-      const player = state.players.find((p) => p.uuid === uuid);
+			return (
+				<Layout page="User" header={<PlayerControl player={player} />}>
+					<PlayerLayout state={state} player={player} />
+				</Layout>
+			);
+		},
+		{
+			params: t.Object({
+				uuid: t.String(),
+			}),
+		},
+	)
+	.post(
+		"/players/:uuid/surrender",
+		({ params: { uuid }, store: { state } }) => {
+			playerSurrender(state, uuid);
+		},
+	)
+	.get(
+		"/players/:uuid/sse",
+		({ params: { uuid }, set, store: { state }, request }) => {
+			const player = state.players.find((p) => p.uuid === uuid);
 
-      if (!player) {
-        // No player found, so return 404
-        console.error("Player not found", uuid);
-        set.status = 404;
-        return;
-      }
+			if (!player) {
+				// No player found, so return 404
+				console.error("Player not found", uuid);
+				set.status = 404;
+				return;
+			}
 
-      return createSSEResponse(state, request, [
-        (state, event) => {
-          if (event.type === "player-answer" && event.uuid === player.uuid) {
-            return [
-              {
-                event: "stats",
-                data: `${(
-                  <PlayerStats state={state} player={player} log={event.log} />
-                )}`,
-              },
-              {
-                event: "log",
-                data: `${(<QuestionTableRow log={event.log} />)}`,
-              },
-            ];
-          }
-          return [];
-        },
-      ]);
-    }
-  );
+			return createSSEResponse(state, request, [
+				(state, event) => {
+					if (event.type === "player-answer" && event.uuid === player.uuid) {
+						return [
+							{
+								event: "stats",
+								data: `${<PlayerStats state={state} player={player} log={event.log} />}`,
+							},
+							{
+								event: "log",
+								data: `${<QuestionTableRow log={event.log} />}`,
+							},
+						];
+					}
+					return [];
+				},
+			]);
+		},
+	);

--- a/src/pages/player.tsx
+++ b/src/pages/player.tsx
@@ -3,237 +3,237 @@ import { escape as htmlEscape } from "html-escaper";
 import { HTMLLayout, HXLayout } from "../layouts/main";
 import { basePluginSetup } from "../plugins";
 import {
-	type Player,
-	type State,
-	type PlayerLog,
-	playerSurrender,
+  type Player,
+  type State,
+  type PlayerLog,
+  playerSurrender,
 } from "../game/state";
 import { createSSEResponse } from "../middleware/sse/sse";
 
 interface PlayerLayoutProps {
-	state: State;
-	player: Player;
+  state: State;
+  player: Player;
 }
 
 interface PlayerStatsProps extends PlayerLayoutProps {
-	log?: PlayerLog;
+  log?: PlayerLog;
 }
 
 const PlayerStats = ({ state, player, log }: PlayerStatsProps) => {
-	const { round } = state;
+  const { round } = state;
 
-	return (
-		<div
-			id="counter"
-			class="rounded-2xl z-10 bg-base-100 bg-opacity-80 backdrop-blur-sm drop-shadow-lg stats stats-horizontal text-2xl max-w-full"
-			sse-swap="stats"
-			hx-swap="outerHTML"
-		>
-			<div class="stat place-items-center">
-				<span class="stat-title">Nick</span>
-				<span class="stat-value" safe>
-					{player.nick}
-				</span>
-			</div>
-			<div class="stat place-items-center">
-				<span class="stat-title">Round</span>
-				<span class="stat-value">{round}</span>
-			</div>
-			<div class="stat place-items-center">
-				<span class="stat-title">Score</span>
-				<span class="stat-value">{log?.score ?? 0}</span>
-			</div>
-			<div class="stat place-items-center">
-				<span class="stat-title">Questions</span>
-				<span class="stat-value">{log?.id ?? 0}</span>
-			</div>
-			<div class="stat place-items-center">
-				<span class="stat-title">Answer ratio</span>
-				<span class="stat-value" safe>
-					{Number.isNaN(log?.answerRatio ?? 0)
-						? "N/A"
-						: log?.answerRatio?.toPrecision(2)}
-				</span>
-			</div>
-		</div>
-	);
+  return (
+    <div
+      id="counter"
+      class="rounded-2xl z-10 bg-base-100 bg-opacity-80 backdrop-blur-sm drop-shadow-lg stats stats-horizontal text-2xl max-w-full"
+      sse-swap="stats"
+      hx-swap="outerHTML"
+    >
+      <div class="stat place-items-center">
+        <span class="stat-title">Nick</span>
+        <span class="stat-value" safe>
+          {player.nick}
+        </span>
+      </div>
+      <div class="stat place-items-center">
+        <span class="stat-title">Round</span>
+        <span class="stat-value">{round}</span>
+      </div>
+      <div class="stat place-items-center">
+        <span class="stat-title">Score</span>
+        <span class="stat-value">{log?.score ?? 0}</span>
+      </div>
+      <div class="stat place-items-center">
+        <span class="stat-title">Questions</span>
+        <span class="stat-value">{log?.id ?? 0}</span>
+      </div>
+      <div class="stat place-items-center">
+        <span class="stat-title">Answer ratio</span>
+        <span class="stat-value" safe>
+          {Number.isNaN(log?.answerRatio ?? 0)
+            ? "N/A"
+            : log?.answerRatio?.toPrecision(2)}
+        </span>
+      </div>
+    </div>
+  );
 };
 
 export const PlayerControl = ({ player }: { player: Player }) => {
-	return (
-		<form
-			class="z-10 flex flex-row items-center"
-			method="POST"
-			action={`/players/${player.uuid}/surrender`}
-		>
-			{player.playing ? (
-				<button
-					class="btn btn-outline btn-error"
-					type="submit"
-					hx-post={`/players/${player.uuid}/surrender`}
-					hx-swap="outerHTML"
-				>
-					Surrender
-				</button>
-			) : (
-				<button
-					class="btn btn-outline btn-success"
-					type="submit"
-					hx-post={`/players/${player.uuid}/play`}
-					hx-swap="outerHTML"
-				>
-					Rejoin
-				</button>
-			)}
-		</form>
-	);
+  return (
+    <form
+      class="z-10 flex flex-row items-center"
+      method="POST"
+      action={`/players/${player.uuid}/surrender`}
+    >
+      {player.playing ? (
+        <button
+          class="btn btn-outline btn-error"
+          type="submit"
+          hx-post={`/players/${player.uuid}/surrender`}
+          hx-swap="outerHTML"
+        >
+          Surrender
+        </button>
+      ) : (
+        <button
+          class="btn btn-outline btn-success"
+          type="submit"
+          hx-post={`/players/${player.uuid}/play`}
+          hx-swap="outerHTML"
+        >
+          Rejoin
+        </button>
+      )}
+    </form>
+  );
 };
 
 const QuestionTableRow = ({ log }: { log: PlayerLog }) => {
-	return (
-		<tr
-			class="odd:bg-base-300"
-			id={`log-${log.id}`}
-			hx-swap="outerHTML"
-			sse-swap={`log-update-${log.id}`}
-		>
-			<th safe>{new Date(log.date).toLocaleTimeString()}</th>
-			<td safe>{log.question}</td>
-			<td>
-				{log.answer ? (
-					<span
-						safe
-						class={`${log.points > 0 ? "text-success" : "text-error"}`}
-					>
-						{htmlEscape(log.answer).substring(0, 500)}
-					</span>
-				) : (
-					"N/A"
-				)}
-			</td>
-			<td>{log.statusCode ?? "N/A"}</td>
-			<td>{log.error ? <span class="text-error">{log.error}</span> : null}</td>
-			<td>{(log.questionInterval ?? 0) / 1000}</td>
-			<td>{log.points}</td>
-			<td>{log.score}</td>
-		</tr>
-	);
+  return (
+    <tr
+      class="odd:bg-base-300"
+      id={`log-${log.id}`}
+      hx-swap="outerHTML"
+      sse-swap={`log-update-${log.id}`}
+    >
+      <th safe>{new Date(log.date).toLocaleTimeString()}</th>
+      <td safe>{log.question}</td>
+      <td>
+        {log.answer ? (
+          <span
+            safe
+            class={`${log.points > 0 ? "text-success" : "text-error"}`}
+          >
+            {htmlEscape(log.answer).substring(0, 500)}
+          </span>
+        ) : (
+          "N/A"
+        )}
+      </td>
+      <td>{log.statusCode ?? "N/A"}</td>
+      <td>{log.error ? <span class="text-error">{log.error}</span> : null}</td>
+      <td>{(log.questionInterval ?? 0) / 1000}</td>
+      <td>{log.points}</td>
+      <td>{log.score}</td>
+    </tr>
+  );
 };
 
 const QuestionTable = (player: Player) => {
-	return (
-		<div class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm drop-shadow-lg flex flex-col grow overflow-x-auto min-h-full">
-			<table class="table">
-				<thead>
-					<tr>
-						<th>Time</th>
-						<th>Question</th>
-						<th>Answer</th>
-						<th>HTTP</th>
-						<th>Error</th>
-						<th>Question rate</th>
-						<th>Points</th>
-						<th>Score</th>
-					</tr>
-				</thead>
-				<tbody class="auto-animate" sse-swap="log" hx-swap="afterbegin">
-					{
-						// For performance reasons, only show the last 50 logs
-						player.log
-							.slice(0, 50)
-							.map((log) => (
-								// biome-ignore lint/correctness/useJsxKeyInIterable: <explanation>
-								<QuestionTableRow log={log} />
-							))
-					}
-				</tbody>
-			</table>
-		</div>
-	);
+  return (
+    <div class="rounded-2xl z-10 bg-base-100 p-8 bg-opacity-80 backdrop-blur-sm drop-shadow-lg flex flex-col grow overflow-x-auto min-h-full">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Question</th>
+            <th>Answer</th>
+            <th>HTTP</th>
+            <th>Error</th>
+            <th>Question rate</th>
+            <th>Points</th>
+            <th>Score</th>
+          </tr>
+        </thead>
+        <tbody class="auto-animate" sse-swap="log" hx-swap="afterbegin">
+          {
+            // For performance reasons, only show the last 50 logs
+            player.log.slice(0, 50).map((log) => (
+              // biome-ignore lint/correctness/useJsxKeyInIterable: <explanation>
+              <QuestionTableRow log={log} />
+            ))
+          }
+        </tbody>
+      </table>
+    </div>
+  );
 };
 
 export const PlayerLayout = ({ player, state }: PlayerLayoutProps) => {
-	return (
-		<div
-			class="epic flex flex-col grow gap-8 pt-8"
-			hx-ext="sse"
-			sse-connect={`/players/${player.uuid}/sse`}
-		>
-			<PlayerStats player={player} state={state} log={player.log[0]} />
-			<QuestionTable {...player} />
-		</div>
-	);
+  return (
+    <div
+      class="epic flex flex-col grow gap-8 pt-8"
+      hx-ext="sse"
+      sse-connect={`/players/${player.uuid}/sse`}
+    >
+      <PlayerStats player={player} state={state} log={player.log[0]} />
+      <QuestionTable {...player} />
+    </div>
+  );
 };
 
 export const plugin = basePluginSetup()
-	.get(
-		"/players/:uuid",
-		({ htmx, params: { uuid }, store: { state } }) => {
-			const Layout = htmx.is ? HXLayout : HTMLLayout;
-			const player = state.players.find((p) => p.uuid === uuid);
+  .get(
+    "/players/:uuid",
+    ({ htmx, params: { uuid }, store: { state } }) => {
+      const Layout = htmx.is ? HXLayout : HTMLLayout;
+      const player = state.players.find((p) => p.uuid === uuid);
 
-			if (!player) {
-				return (
-					<Layout page="User">
-						<div class="flex flex-col">
-							<h1 class="">Player not found</h1>
-							<p>
-								<a class="link link-success" href="/signup">
-									Create a new player
-								</a>{" "}
-								to compete.
-							</p>
-						</div>
-					</Layout>
-				);
-			}
+      if (!player) {
+        return (
+          <Layout page="User">
+            <div class="flex flex-col">
+              <h1 class="">Player not found</h1>
+              <p>
+                <a class="link link-success" href="/signup" hx-push-url="true">
+                  Create a new player
+                </a>{" "}
+                to compete.
+              </p>
+            </div>
+          </Layout>
+        );
+      }
 
-			return (
-				<Layout page="User" header={<PlayerControl player={player} />}>
-					<PlayerLayout state={state} player={player} />
-				</Layout>
-			);
-		},
-		{
-			params: t.Object({
-				uuid: t.String(),
-			}),
-		},
-	)
-	.post(
-		"/players/:uuid/surrender",
-		({ params: { uuid }, store: { state } }) => {
-			playerSurrender(state, uuid);
-		},
-	)
-	.get(
-		"/players/:uuid/sse",
-		({ params: { uuid }, set, store: { state }, request }) => {
-			const player = state.players.find((p) => p.uuid === uuid);
+      return (
+        <Layout page="User" header={<PlayerControl player={player} />}>
+          <PlayerLayout state={state} player={player} />
+        </Layout>
+      );
+    },
+    {
+      params: t.Object({
+        uuid: t.String(),
+      }),
+    }
+  )
+  .post(
+    "/players/:uuid/surrender",
+    ({ params: { uuid }, store: { state } }) => {
+      playerSurrender(state, uuid);
+    }
+  )
+  .get(
+    "/players/:uuid/sse",
+    ({ params: { uuid }, set, store: { state }, request }) => {
+      const player = state.players.find((p) => p.uuid === uuid);
 
-			if (!player) {
-				// No player found, so return 404
-				console.error("Player not found", uuid);
-				set.status = 404;
-				return;
-			}
+      if (!player) {
+        // No player found, so return 404
+        console.error("Player not found", uuid);
+        set.status = 404;
+        return;
+      }
 
-			return createSSEResponse(state, request, [
-				(state, event) => {
-					if (event.type === "player-answer" && event.uuid === player.uuid) {
-						return [
-							{
-								event: "stats",
-								data: `${<PlayerStats state={state} player={player} log={event.log} />}`,
-							},
-							{
-								event: "log",
-								data: `${<QuestionTableRow log={event.log} />}`,
-							},
-						];
-					}
-					return [];
-				},
-			]);
-		},
-	);
+      return createSSEResponse(state, request, [
+        (state, event) => {
+          if (event.type === "player-answer" && event.uuid === player.uuid) {
+            return [
+              {
+                event: "stats",
+                data: `${(
+                  <PlayerStats state={state} player={player} log={event.log} />
+                )}`,
+              },
+              {
+                event: "log",
+                data: `${(<QuestionTableRow log={event.log} />)}`,
+              },
+            ];
+          }
+          return [];
+        },
+      ]);
+    }
+  );

--- a/src/pages/scoreboard/scoreboard.tsx
+++ b/src/pages/scoreboard/scoreboard.tsx
@@ -1,9 +1,9 @@
-import { HTMLLayout, HXLayout } from "../../layouts/main";
-import { basePluginSetup } from "../../plugins";
-import type { Player } from "../../game/state";
-import { createSSEResponse } from "../../middleware/sse/sse";
 import type { ChartConfiguration } from "chart.js";
+import type { Player } from "../../game/state";
 import { splitArrayAt } from "../../helpers/helpers";
+import { HTMLLayout, HXLayout } from "../../layouts/main";
+import { createSSEResponse } from "../../middleware/sse/sse";
+import { basePluginSetup } from "../../plugins";
 
 const PlayerRow = ({ player }: { player: Player }) => {
 	return (

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,8 +1,8 @@
 import { type ValidationError, t } from "elysia";
+import { addPlayer } from "../game/state";
 import { mapValidationError } from "../helpers/helpers";
 import { HTMLLayout, HXLayout, HeroLayout } from "../layouts/main";
 import { basePluginSetup } from "../plugins";
-import { addPlayer } from "../game/state";
 
 interface FormProps {
 	url?: string;

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,7 +1,7 @@
 import { Elysia } from "elysia";
+import { state } from "./game/state";
 import { htmlPlugin } from "./middleware/html/html";
 import { htmxPlugin } from "./middleware/htmx/htmx";
-import { state } from "./game/state";
 
 export const basePluginSetup = () => {
 	return new Elysia({


### PR DESCRIPTION
Add hx-push-url="true" to anchor tags to tell HTMX to use push history. This makes it store pages/fragments in local storage as a history allowing back and forward navigation without refetching HTML pages or fragments from the server.

Add hx-boost to the body element in layout to ensure hx-push-url and history works correctly on all pages.

Fix #17 