### PR TITLE
chore: Add player to scoreboard when they join

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
   "editor.defaultFormatter": "biomejs.biome",
   "editor.formatOnSave": true,
   "outline.collapseItems": "alwaysExpand",
-  "editor.foldingImportsByDefault": false
+  "editor.foldingImportsByDefault": false,
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -165,12 +165,12 @@ htmx.on("htmx:sseMessage", (evt) => {
 		sortScoreboard();
 	}
 
-	// If the event is a player-chart event, update the chart with the new data
+	// If the event is a player-score-chart event, update the chart with the new score data
 	if (
 		evt instanceof CustomEvent &&
-		evt.detail.type.startsWith("player-chart-")
+		evt.detail.type.startsWith("player-score-chart-")
 	) {
-		const nick = evt.detail.type.replace("player-chart-", "");
+		const nick = evt.detail.type.replace("player-score-chart-", "");
 		const data = JSON.parse(evt.detail.data);
 		const dataset = chart.data.datasets.find((d) => d.label === nick);
 
@@ -178,5 +178,12 @@ htmx.on("htmx:sseMessage", (evt) => {
 			dataset.data.push(data);
 			chart.update();
 		}
+	}
+
+	// If the event is a player-joined-chart event, add the player to the chart
+	if (evt instanceof CustomEvent && evt.detail.type === "player-joined-chart") {
+		const data = JSON.parse(evt.detail.data);
+		chart.data.datasets.push(data);
+		chart.update();
 	}
 });


### PR DESCRIPTION
When the player join they should be added to the scoreboard. Set up sse events for the player joined game state event. Add both to scoreboard list and to the chart.js datasets.