### PR TITLE
fix: Player score not updated

### DIFF
--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -138,6 +138,7 @@ const newWorker = (player: Player) => {
 					const player = state.players.find((p) => p.uuid === uuid);
 					if (player) {
 						player.log.unshift(log);
+						player.score += log.score;
 					}
 					// We need to notify all relevant listeners about the new log
 					// Multiple listeners can be listening for the same player

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -252,7 +252,7 @@ const PlayerRow = (player: Player) => {
 			</td>
 			<td safe>{player.url}</td>
 			<td sse-swap={`player-score-${player.uuid}`} hx-swap="innerHTML">
-				{player.log?.[0]?.score ?? 0}
+				{player.score ?? 0}
 			</td>
 			<td>
 				{player.playing ? (

--- a/src/pages/scoreboard/scoreboard.tsx
+++ b/src/pages/scoreboard/scoreboard.tsx
@@ -21,7 +21,7 @@ const PlayerRow = ({ player }: { player: Player }) => {
 				hx-swap="innerHTML"
 				sse-swap={`player-score-${player.nick}`}
 			>
-				{player.log[0]?.score ?? 0}
+				{player.score}
 			</span>
 			<span // Use a hidden element to swap the chart data, don't actually swap json into the DOM
 				class="hidden"
@@ -132,7 +132,7 @@ export const scoreboardPlugin = basePluginSetup()
 	.get("/scoreboard/winners", ({ htmx, store: { state } }) => {
 		const Layout = htmx.is ? HXLayout : HTMLLayout;
 		const winners = state.players
-			.toSorted((a, b) => (b.log[0]?.score ?? 0) - (a.log[0]?.score ?? 0))
+			.toSorted((a, b) => b.score - a.score)
 			.slice(0, 3);
 		const medals = ["🥇", "🥈", "🥉"];
 		return (
@@ -198,7 +198,7 @@ export const scoreboardPlugin = basePluginSetup()
 										data: [
 											{
 												x: new Date().toISOString(),
-												y: player.log[0]?.score ?? 0,
+												y: player.score,
 											},
 										],
 										borderColor: player.color.hex,


### PR DESCRIPTION
When syncing player answer logs to main thread it only updated the player log, not the player score. This broke UI that used the player.score property rather than looking up the last score in the player.log. Fixed game module so player score is updated correctly. Changed some UI components to use the player.score property as this should always be set.